### PR TITLE
Make isXenograft non-required

### DIFF
--- a/NF.csv
+++ b/NF.csv
@@ -765,7 +765,7 @@ specimenPreparationMethod,"Term that represents preservation of the sample befor
 age,A numeric value representing age of the individual. Use with ageUnit.,,ageUnit,FALSE,Sage Bionetworks,,,,num,age,DataProperty,Biosample,annotationProperty,biosampleAnnotation,,,
 ageUnit,"A time unit that can be used with a given age value, e.g. years.","days, months, years",,FALSE,Sage Bionetworks,,,,,ageUnit,Property,Biosample,annotationProperty,biosampleAnnotation,,,
 bioSampleUsed,The biosample used.,,,,,,,,,,,,,,,,
-isXenograft,Whether or not sample source is a xenograft (Yes; No),"Yes, No",,TRUE,,experimentalData,,,,isXenograft,DataProperty,Biosample,annotationProperty,,,,
+isXenograft,Whether or not sample source is a xenograft (Yes; No),"Yes, No",,FALSE,,experimentalData,,,,isXenograft,DataProperty,Biosample,annotationProperty,,,,
 sourceName," identifies the source from where the sample is derived. If the sample assayed is a nanoparticle sample or some chemical substance not derived from a biological material, then the corresponding source name should refer to the starting sample that was modified by a protocol for the assay.","",,TRUE,,sourceName,,,,sourceName,Property,Sample,annotationProperty,,,,
 sampleType,"Type of sample","",,FALSE,,sampleType,,,,molecularSpecies,Property,Sample,annotationProperty,,,,"Not used directly in template since each template already implicitly assumes either a biospecimen sample or chemical sample; this is a super-property for organization purposes"
 materialType,"Type of material in the characterization","nanoparticles,polymeric nanoparticles,small molecule,DNA",,FALSE,,sampleType,,,,materialType,Property,Material,annotationProperty,,,,

--- a/NF.jsonld
+++ b/NF.jsonld
@@ -17602,7 +17602,7 @@
                 }
             ],
             "sms:displayName": "isXenograft",
-            "sms:required": "sms:true",
+            "sms:required": "sms:false",
             "sms:validationRules": []
         },
         {

--- a/modules/Sample/annotationProperty.csv
+++ b/modules/Sample/annotationProperty.csv
@@ -25,7 +25,7 @@ specimenPreparationMethod,"Term that represents preservation of the sample befor
 age,A numeric value representing age of the individual. Use with ageUnit.,,ageUnit,FALSE,Sage Bionetworks,,,,num,age,DataProperty,Biosample,annotationProperty,biosampleAnnotation,,,
 ageUnit,"A time unit that can be used with a given age value, e.g. years.","days, months, years",,FALSE,Sage Bionetworks,,,,,ageUnit,Property,Biosample,annotationProperty,biosampleAnnotation,,,
 bioSampleUsed,The biosample used.,,,,,,,,,,,,,,,,
-isXenograft,Whether or not sample source is a xenograft (Yes; No),"Yes, No",,TRUE,,experimentalData,,,,isXenograft,DataProperty,Biosample,annotationProperty,,,,
+isXenograft,Whether or not sample source is a xenograft (Yes; No),"Yes, No",,FALSE,,experimentalData,,,,isXenograft,DataProperty,Biosample,annotationProperty,,,,
 sourceName," identifies the source from where the sample is derived. If the sample assayed is a nanoparticle sample or some chemical substance not derived from a biological material, then the corresponding source name should refer to the starting sample that was modified by a protocol for the assay.","",,TRUE,,sourceName,,,,sourceName,Property,Sample,annotationProperty,,,,
 sampleType,"Type of sample","",,FALSE,,sampleType,,,,molecularSpecies,Property,Sample,annotationProperty,,,,"Not used directly in template since each template already implicitly assumes either a biospecimen sample or chemical sample; this is a super-property for organization purposes"
 materialType,"Type of material in the characterization","nanoparticles,polymeric nanoparticles,small molecule,DNA",,FALSE,,sampleType,,,,materialType,Property,Material,annotationProperty,,,,


### PR DESCRIPTION
Discovered during testing that `isXenograft` somehow had a required value, but it shouldn't be.