### PR TITLE
Add logic for superdataset

### DIFF
--- a/registered-json-schemas/superdataset.json
+++ b/registered-json-schemas/superdataset.json
@@ -137,6 +137,13 @@
             "concreteType": {
                 "const": "org.sagebionetworks.repo.model.Folder"
             }
+        },
+        "not": {
+            "properties": {
+                "name": {
+                    "const": "Raw Data"
+                }
+            }
         }
     },
     "then": {


### PR DESCRIPTION
This has been tested and applied, PR is for awareness. To see test:

1. See that "Raw Data" does not have `contentType=dataset` but its child folder "My Assay Data" does in [this view](https://www.synapse.org/#!Synapse:syn51106457/tables/).
2. If name of "Raw Data" is changed is something else, it acquires `contentType=dataset`. Can also see this with the top-level "Data" folder because rule uses exact name matching.

Some pitfalls:
- Yes, if you have a "Raw Data" under "Raw Data", it will be hidden (please use better names for your assay data folders?)
