### PR TITLE
Patch/sync issue 336

### DIFF
--- a/.github/workflows/trigger-sync-dcc-site.yml
+++ b/.github/workflows/trigger-sync-dcc-site.yml
@@ -1,0 +1,27 @@
+# Trigger dcc-site to create a PR for its `main` self that pulls in data model changes into study-schema drop-down options
+# whenever there are pushes to `main` with relevant model changes
+
+name: Sync dcc-site
+
+on:
+  push:
+    branches: 
+      - main
+    paths:
+      - NF.jsonld
+      
+env:
+  REPO: nf-osi/dcc-site
+  REF: refs/heads/main
+      
+jobs:
+  trigger-sync:
+    runs-on: ubuntu-latest
+    steps:
+    
+      - uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Handle data model update
+          repo: ${{ env.REPO }}
+          ref: ${{ env.REF }}
+          token: ${{ secrets.SERVICE_TOKEN }}

--- a/NF.jsonld
+++ b/NF.jsonld
@@ -588,6 +588,10 @@
     }, {
       "@id" : "bts:IndianaUniversity,Bloomington"
     }, {
+      "@id" : "bts:Institutd'InvestigacióenCiènciesdelaSalutGermansTriasiPujol"
+    }, {
+      "@id" : "bts:Institutd'InvestigacióBiomédicadeBellvitge"
+    }, {
       "@id" : "bts:UniversityofMassachusetts,Lowell"
     }, {
       "@id" : "bts:NorthernIllinoisUniversity"
@@ -624,6 +628,8 @@
     }, {
       "@id" : "bts:CaliforniaStateUniversity,LongBeach"
     }, {
+      "@id" : "bts:L’InsermdansParisetl’Île-de-FranceCentreNord"
+    }, {
       "@id" : "bts:IowaStateUniversity"
     }, {
       "@id" : "bts:VanAndelResearchInstitute"
@@ -635,6 +641,10 @@
       "@id" : "bts:UniversityofToledo"
     }, {
       "@id" : "bts:UniversityofLouisville"
+    }, {
+      "@id" : "bts:UniversityofPlymouth"
+    }, {
+      "@id" : "bts:UniversityofTurku"
     }, {
       "@id" : "bts:HarvardUniversity"
     }, {
@@ -8173,6 +8183,17 @@
     "sms:displayName" : "Medical University of South Carolina",
     "sms:required" : "sms:false"
   }, {
+    "@id" : "bts:Institutd'InvestigacióBiomédicadeBellvitge",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "Institutd'InvestigacióBiomédicadeBellvitge",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "Institut d'Investigació Biomédica de Bellvitge",
+    "sms:required" : "sms:false"
+  }, {
     "@id" : "bts:bluenativePAGE",
     "@type" : "rdfs:Class",
     "rdfs:comment" : "TBD",
@@ -8413,6 +8434,17 @@
       "@id" : "http://schema.biothings.io/"
     },
     "sms:displayName" : "blood",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:Institutd'InvestigacióenCiènciesdelaSalutGermansTriasiPujol",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "Institutd'InvestigacióenCiènciesdelaSalutGermansTriasiPujol",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "Institut d'Investigació en Ciències de la Salut Germans Trias i Pujol",
     "sms:required" : "sms:false"
   }, {
     "@id" : "bts:singleEnd",
@@ -9317,6 +9349,17 @@
     "sms:displayName" : "groin",
     "sms:required" : "sms:false"
   }, {
+    "@id" : "bts:UniversityofPlymouth",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "UniversityofPlymouth",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "University of Plymouth",
+    "sms:required" : "sms:false"
+  }, {
     "@id" : "bts:jumpinglibrary",
     "@type" : "rdfs:Class",
     "rdfs:comment" : "TBD",
@@ -9656,6 +9699,17 @@
       "@id" : "http://schema.biothings.io/"
     },
     "sms:displayName" : "ribo-seq",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:UniversityofTurku",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "UniversityofTurku",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "University of Turku",
     "sms:required" : "sms:false"
   }, {
     "@id" : "bts:Smart-seq4",
@@ -14727,6 +14781,17 @@
       "@id" : "http://schema.biothings.io/"
     },
     "sms:displayName" : "CNON",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:L’InsermdansParisetl’Île-de-FranceCentreNord",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "L’InsermdansParisetl’Île-de-FranceCentreNord",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "L’Inserm dans Paris et l’Île-de-France Centre Nord",
     "sms:required" : "sms:false"
   }, {
     "@id" : "bts:DuquesneUniversity",

--- a/modules/Other/Organization.yaml
+++ b/modules/Other/Organization.yaml
@@ -45,6 +45,10 @@ enums:
         description: ''
       Indiana University, Bloomington:
         description: ''
+      Institut d'Investigació en Ciències de la Salut Germans Trias i Pujol:
+        description: ''
+      Institut d'Investigació Biomédica de Bellvitge:
+        description: ''
       University of Massachusetts, Lowell:
         description: ''
       Northern Illinois University:
@@ -81,6 +85,8 @@ enums:
         description: ''
       California State University, Long Beach:
         description: ''
+      L’Inserm dans Paris et l’Île-de-France Centre Nord:
+        description: ''
       Iowa State University:
         description: ''
       Van Andel Research Institute:
@@ -92,6 +98,10 @@ enums:
       University of Toledo:
         description: ''
       University of Louisville:
+        description: ''
+      University of Plymouth:
+        description: ''
+      University of Turku:  
         description: ''
       Harvard University:
         description: ''


### PR DESCRIPTION
Some more dcc-site focused changes -- waiting for #346, I will rebase this onto whatever changes are finalized there. ✔️ 

Close #336:
- Add workflow so that data model updates will trigger dcc-site to pull in changes automatically (we needed to set up the script on dcc-site side first, which was done a couple of sprints ago).
- Update some institutions -- not used in DCA templates so tests are skipped.