### PR TITLE
Patch/schematic update

### DIFF
--- a/.github/workflows/schematic-ci.yml
+++ b/.github/workflows/schematic-ci.yml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, '[skip schematic]') }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
@@ -45,27 +45,33 @@ jobs:
   # Additionally test PRs
   test:
     name: Test with schematic
-    if: "!contains( github.event.pull_request.labels.*.name, 'skip tests')"
     needs: [build]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       SCHEMATIC_SERVICE_ACCT_CREDS: ${{ secrets.SCHEMATIC_SERVICE_ACCT_CREDS }}
     permissions:
       pull-requests: write
     strategy:
       matrix:
-        schematic-version: [23.9.1]
+        schematic-version: [24.1.1]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 1
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10.12' 
+      
       - name: Setup schematic
         id: setup-schematic
-        run: pip3 install schematicpy==${{ matrix.schematic-version }}
+        run: pip install schematicpy==${{ matrix.schematic-version }}
 
+      - name: Sanity-check successful installation and version
+        run: pip show schematicpy
+      
       - name: Test generate
         working-directory: tests/generate
         continue-on-error: true

--- a/NF.jsonld
+++ b/NF.jsonld
@@ -16,7 +16,13 @@
     },
     "sms:required" : "sms:false",
     "schema:rangeIncludes" : [ {
+      "@id" : "bts:EutropicsPharmaceuticals"
+    }, {
       "@id" : "bts:CincinnatiChildren'sHospitalMedicalCenter"
+    }, {
+      "@id" : "bts:MemorialSloaneKetteringCancerCenter"
+    }, {
+      "@id" : "bts:Dana-FarberCancerInstitute"
     }, {
       "@id" : "bts:MassachusettsGeneralHospital"
     }, {
@@ -109,6 +115,8 @@
       "@id" : "bts:VanAndelResearchInstitute"
     }, {
       "@id" : "bts:UniversityofCalifornia,Irvine"
+    }, {
+      "@id" : "bts:UniversityofCambridge"
     }, {
       "@id" : "bts:UniversityofNorthCarolina,Greensboro"
     }, {
@@ -11951,6 +11959,17 @@
     "sms:displayName" : "CRISPR",
     "sms:required" : "sms:false"
   }, {
+    "@id" : "bts:Dana-FarberCancerInstitute",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "Dana-FarberCancerInstitute",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "Dana-Farber Cancer Institute",
+    "sms:required" : "sms:false"
+  }, {
     "@id" : "bts:AlbertEinsteinCollegeofMedicine",
     "@type" : "rdfs:Class",
     "rdfs:comment" : "TBD",
@@ -13777,6 +13796,17 @@
     "sms:displayName" : "calcium retention capacity assay",
     "sms:required" : "sms:false"
   }, {
+    "@id" : "bts:MemorialSloaneKetteringCancerCenter",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "MemorialSloaneKetteringCancerCenter",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "Memorial Sloane Kettering Cancer Center",
+    "sms:required" : "sms:false"
+  }, {
     "@id" : "bts:HS-PSS",
     "@type" : "rdfs:Class",
     "rdfs:comment" : "TBD",
@@ -13984,6 +14014,17 @@
       "@id" : "http://schema.biothings.io/"
     },
     "sms:displayName" : "Rockefeller University",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:UniversityofCambridge",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "UniversityofCambridge",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "University of Cambridge",
     "sms:required" : "sms:false"
   }, {
     "@id" : "bts:braingrowthmeasurement",
@@ -21860,6 +21901,17 @@
       "@id" : "http://schema.biothings.io/"
     },
     "sms:displayName" : "FLIPR high-throughput cellular screening",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:EutropicsPharmaceuticals",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "EutropicsPharmaceuticals",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "Eutropics Pharmaceuticals",
     "sms:required" : "sms:false"
   }, {
     "@id" : "bts:Nf1-OPG",

--- a/modules/Other/Organization.yaml
+++ b/modules/Other/Organization.yaml
@@ -1,8 +1,11 @@
 enums:
   Institution:
     permissible_values:
+      Eutropics Pharmaceuticals:
       Cincinnati Children's Hospital Medical Center:
         meaning: https://ror.org/01hcyya48
+      Memorial Sloane Kettering Cancer Center:
+      Dana-Farber Cancer Institute:
       Massachusetts General Hospital:
         description: ''
       University of Tennessee, Health Science Center:
@@ -95,6 +98,7 @@ enums:
         description: ''
       University of California, Irvine:
         description: ''
+      University of Cambridge:
       University of North Carolina, Greensboro:
         description: ''
       University of Toledo:

--- a/tests/generate/basic_templates.sh
+++ b/tests/generate/basic_templates.sh
@@ -37,8 +37,7 @@ mkdir -p $LOG_DIR
 for i in ${!TEMPLATES[@]}
 do
   echo ">>>>>>> Generating ${TEMPLATES[$i]}"
-  schematic manifest --config config.yml \
-  get -dt ${TEMPLATES[$i]} --title ${TEMPLATES[$i]} -s | tee $LOG_DIR/${TEMPLATES[$i]%.*}_log.txt
+  schematic manifest --config ./config.yml get -dt "${TEMPLATES[$i]}" --title "${TEMPLATES[$i]}" -s | tee $LOG_DIR/${TEMPLATES[$i]%.*}_log
   sleep $SLEEP_THROTTLE
 done
 

--- a/tests/test-suite-report.Rmd
+++ b/tests/test-suite-report.Rmd
@@ -27,7 +27,7 @@ md_link <- function (url) {
 
 ```{r parse-generation-logs, echo=FALSE}
 gen_logs <- list.files("generate/logs", full.names = TRUE)
-templates <- gsub("_.*", "", basename(gen_logs))
+templates <- gsub("_log", "", basename(gen_logs))
 gen_test_results <- lapply(gen_logs, readLines)
 gen_test_links <- sapply(gen_test_results, md_link)
 gen_test_reaction <- sapply(lengths(gen_test_results), test_reaction) 


### PR DESCRIPTION
- Update schematic CI to use **24.1.1** for generating templates, validating templates in test suite
  - Note: for some reason, absolutely cannot use Python 3.10.04 (default version on ubuntu-22.04) with schematic 24.1.1, this was a weird error to hunt down
- Add new institutions to test changes + accommodate DSP submissions

**Reviewers added for awareness/to confirm that things are updated and functionality remains fine**