### PR TITLE
Fix case-insensitive bug from schematic upgrade

### DIFF
--- a/NF.jsonld
+++ b/NF.jsonld
@@ -9,6 +9,3688 @@
   },
   "@id" : "http://schema.biothings.io/",
   "@graph" : [ {
+    "@id" : "bts:BodyPartEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "BodyPartEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "BodyPartEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:UnknownEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "UnknownEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "UnknownEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:SpecimenPreparationMethodEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "SpecimenPreparationMethodEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "SpecimenPreparationMethodEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:DataSubtypeEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "DataSubtypeEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "DataSubtypeEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:FileFormatEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "FileFormatEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "FileFormatEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:MultipleImagingDiagnosisEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "Enumerations describing the manifestation of tumors confirmed via imaging with one or multiple sites being the most relevant result.",
+    "rdfs:label" : "MultipleImagingDiagnosisEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "MultipleImagingDiagnosisEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:SexEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "SexEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "SexEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:MRISequenceEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "MRISequenceEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "MRISequenceEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:AgeGroupEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "AgeGroupEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "AgeGroupEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:TumorTreatmentEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "TumorTreatmentEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "TumorTreatmentEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:PlatformEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "PlatformEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "PlatformEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:NF1Variant",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "NF1Variant",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "NF1Variant",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:GenePerturbationEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "GenePerturbationEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "GenePerturbationEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:TestSummaryEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "TestSummaryEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "TestSummaryEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:SpinalNeuromaManifestationEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "Enumerations describing the manifestation of spinal neurofibromas, combining information on presence and the cervical locations.",
+    "rdfs:label" : "SpinalNeuromaManifestationEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "SpinalNeuromaManifestationEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:WorkflowEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "WorkflowEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "WorkflowEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:BooleanEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "Boolean data as Yes/No enums",
+    "rdfs:label" : "BooleanEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "BooleanEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:PubertyOnsetEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "PubertyOnsetEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "PubertyOnsetEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:GenePerturbationMethodEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "GenePerturbationMethodEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "GenePerturbationMethodEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:Data",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "Data",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "Data",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:PlexiformNeurofibromaManifestationEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "Enumerations describing the manifestation of plexiform neurofibromas, combining information on presence and the certainty via MRI imaging technique.",
+    "rdfs:label" : "PlexiformNeurofibromaManifestationEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "PlexiformNeurofibromaManifestationEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:BinaryImagingDiagnosisEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "Enumerations describing the manifestation of tumors confirmed via imaging with mainly absent or present being the most relevant result.",
+    "rdfs:label" : "BinaryImagingDiagnosisEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "BinaryImagingDiagnosisEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:SpeciesEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "SpeciesEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "SpeciesEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:DiagnosisEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "DiagnosisEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "DiagnosisEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:ProteinExtractSourceEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "ProteinExtractSourceEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "ProteinExtractSourceEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:VitalStatusEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "VitalStatusEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "VitalStatusEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:MosaicismEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "MosaicismEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "MosaicismEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:WorkingDistanceUnitEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "WorkingDistanceUnitEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "WorkingDistanceUnitEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:StrandednessEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "StrandednessEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "StrandednessEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:OrganismSubstance",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "This preferred root in the UBERON ontology is meant to cover organism-produced substances (bodily secretions and excreta) commonly used as assay specimens.",
+    "rdfs:label" : "OrganismSubstance",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "OrganismSubstance",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:BiologicalProcess",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "BiologicalProcess",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "BiologicalProcess",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:ExpressionUnitEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "Quantification units for gene expression.",
+    "rdfs:label" : "ExpressionUnitEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "ExpressionUnitEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:OrganEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "OrganEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "OrganEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:Tumor",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "Tumor",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "Tumor",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:WHOPerformanceStatusScores",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "https://www.ncbi.nlm.nih.gov/books/NBK97482/",
+    "rdfs:label" : "WHOPerformanceStatusScores",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "WHOPerformanceStatusScores",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:ConcentrationUnit",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "ConcentrationUnit",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "ConcentrationUnit",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:NucleicAcidSourceEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "NucleicAcidSourceEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "NucleicAcidSourceEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:ReadPairOrientationEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "ReadPairOrientationEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "ReadPairOrientationEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:LateralManifestationEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "Enumerations describing the manifestation of tumors confirmed via imaging (MRI or other), where lateral information is most relevant.",
+    "rdfs:label" : "LateralManifestationEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "LateralManifestationEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:LibraryPrepEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "LibraryPrepEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "LibraryPrepEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:Percentiles-2SD",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "Enumerations corresponding to 3 bins using 2 standard deviations as a cutoff.",
+    "rdfs:label" : "Percentiles-2SD",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "Percentiles-2SD",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:Tissue",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "Tissue is a group of cells that have similar structure and that function together as a unit.",
+    "rdfs:label" : "Tissue",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "Tissue",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:LibraryPreparationMethodEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "LibraryPreparationMethodEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "LibraryPreparationMethodEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:StudyStatusEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "StudyStatusEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "StudyStatusEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:Metadata",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "Data that provides information about other data",
+    "rdfs:label" : "Metadata",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "Metadata",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:DiseaseFocusEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "DiseaseFocusEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "DiseaseFocusEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:ChannelEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "ChannelEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "ChannelEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:FundingAgencyEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "FundingAgencyEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "FundingAgencyEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:Cell",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "Cell",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "Cell",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:GenomicReferenceEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "GenomicReferenceEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "GenomicReferenceEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:Genotype",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "Genotype",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "Genotype",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:DrugScreen",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "This is a subset of Assay enum above.",
+    "rdfs:label" : "DrugScreen",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "DrugScreen",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:DissociationMethodEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "DissociationMethodEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "DissociationMethodEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:TimeUnit",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "TimeUnit",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "TimeUnit",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:Measurement",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "Measurement",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "Measurement",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:Material",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "Material",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "Material",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:ManifestationEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "ManifestationEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "ManifestationEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:SchwannomaManifestationEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "Enumerations describing the manifestation of schwannomas.",
+    "rdfs:label" : "SchwannomaManifestationEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "SchwannomaManifestationEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:OpticGliomaManifestationEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "Enumerations describing the manifestation of optic gliomas, combining information on presence, symptoms, and treatment.",
+    "rdfs:label" : "OpticGliomaManifestationEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "OpticGliomaManifestationEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:TransplantationType",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "TransplantationType",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "TransplantationType",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:RunTypeEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "RunTypeEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "RunTypeEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:NotApplicableEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "NotApplicableEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "NotApplicableEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:CellLineModel",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "CellLineModel",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "CellLineModel",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:Resource",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "Resource",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "Resource",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:MouseModel",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "MouseModel",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "MouseModel",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:AssayEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "AssayEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "AssayEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:CuratedDataEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "CuratedDataEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "CuratedDataEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:NonvestibularSchwannomaManifestationEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "NonvestibularSchwannomaManifestationEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "NonvestibularSchwannomaManifestationEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:DataStatusEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "DataStatusEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "DataStatusEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:Institution",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "Institution",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "Institution",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:ReadStrandOriginEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "ReadStrandOriginEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "ReadStrandOriginEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:PainEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "PainEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "PainEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:License",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "License attached to the data. If indicates UNKNOWN or RESTRICTED-USE, data may not be used without further contact for terms.",
+    "rdfs:label" : "License",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "License",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:PresenceEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "Enumeration for binary + unknown for very basic classification of a manifestation in clinical context.",
+    "rdfs:label" : "PresenceEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "PresenceEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:NeurofibromaManifestationEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "Enumerations describing how neurofibromas can manifest more generally.",
+    "rdfs:label" : "NeurofibromaManifestationEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "NeurofibromaManifestationEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:InheritanceEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "InheritanceEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "InheritanceEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:AccessTypeEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "AccessTypeEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "AccessTypeEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "@id" : "bts:GenePerturbationTechnologyEnum",
+    "@type" : "rdfs:Class",
+    "rdfs:comment" : "TBD",
+    "rdfs:label" : "GenePerturbationTechnologyEnum",
+    "rdfs:subClassOf" : [ ],
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:displayName" : "GenePerturbationTechnologyEnum",
+    "sms:required" : "sms:false"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:ProteinAssayTemplate"
+    } ],
+    "@id" : "bts:MassSpecAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "MassSpecAssayTemplate",
+    "rdfs:comment" : "Template for raw mass spec-based proteomics data.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:proteinExtractSource"
+    }, {
+      "@id" : "bts:dataCollectionMode"
+    } ],
+    "sms:displayName" : "MassSpecAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BiologicalAssayDataTemplate"
+    } ],
+    "@id" : "bts:ClinicalAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "ClinicalAssayTemplate",
+    "rdfs:comment" : "General template for typically tabular **individual-level** data. This can include repeated measures and a drug treatment context.\n",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:experimentalFactor"
+    }, {
+      "@id" : "bts:experimentalCondition"
+    }, {
+      "@id" : "bts:timepointUnit"
+    }, {
+      "@id" : "bts:compoundName"
+    }, {
+      "@id" : "bts:compoundDose"
+    }, {
+      "@id" : "bts:compoundDoseUnit"
+    } ],
+    "sms:displayName" : "ClinicalAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:ScSequencingAssayTemplate"
+    } ],
+    "@id" : "bts:ScRNASeqTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "ScRNASeqTemplate",
+    "rdfs:comment" : "Template for describing raw data from single-cell RNA-seq.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:nucleicAcidSource"
+    }, {
+      "@id" : "bts:specimenPreparationMethod"
+    }, {
+      "@id" : "bts:cellType"
+    }, {
+      "@id" : "bts:isCellLine"
+    }, {
+      "@id" : "bts:cellID"
+    }, {
+      "@id" : "bts:dissociationMethod"
+    }, {
+      "@id" : "bts:runType"
+    }, {
+      "@id" : "bts:libraryStrand"
+    }, {
+      "@id" : "bts:libraryPrep"
+    }, {
+      "@id" : "bts:libraryPreparationMethod"
+    }, {
+      "@id" : "bts:readPair"
+    }, {
+      "@id" : "bts:readLength"
+    }, {
+      "@id" : "bts:readDepth"
+    }, {
+      "@id" : "bts:targetDepth"
+    }, {
+      "@id" : "bts:batchID"
+    }, {
+      "@id" : "bts:auxiliaryAsset"
+    } ],
+    "sms:displayName" : "ScRNASeqTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BiologicalAssayDataTemplate"
+    } ],
+    "@id" : "bts:ProteinAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "ProteinAssayTemplate",
+    "rdfs:comment" : "Abstract template for data from some assay of protein structure and function. Data should be instantiated with more specific template.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:proteinExtractSource"
+    } ],
+    "sms:displayName" : "ProteinAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BiologicalAssayDataTemplate"
+    } ],
+    "@id" : "bts:GeneralMeasureDataTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "GeneralMeasureDataTemplate",
+    "rdfs:comment" : "General template for data in tabular form that aggregates tissue-level or cellular-level data.\n",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:experimentalFactor"
+    }, {
+      "@id" : "bts:experimentalCondition"
+    }, {
+      "@id" : "bts:experimentalTimepoint"
+    }, {
+      "@id" : "bts:timepointUnit"
+    }, {
+      "@id" : "bts:compoundName"
+    }, {
+      "@id" : "bts:compoundDose"
+    }, {
+      "@id" : "bts:compoundDoseUnit"
+    }, {
+      "@id" : "bts:genePerturbed"
+    }, {
+      "@id" : "bts:genePerturbationType"
+    }, {
+      "@id" : "bts:genePerturbationTechnology"
+    } ],
+    "sms:displayName" : "GeneralMeasureDataTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:NonBiologicalAssayDataTemplate"
+    } ],
+    "@id" : "bts:MaterialScienceAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "MaterialScienceAssayTemplate",
+    "rdfs:comment" : "General template for describing data for a materials science assay.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:materialType"
+    }, {
+      "@id" : "bts:concentrationMaterial"
+    }, {
+      "@id" : "bts:concentrationMaterialUnit"
+    }, {
+      "@id" : "bts:concentrationNaCl"
+    }, {
+      "@id" : "bts:concentrationNaClUnit"
+    } ],
+    "sms:displayName" : "MaterialScienceAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BulkSequencingAssayTemplate"
+    } ],
+    "@id" : "bts:RNASeqTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "RNASeqTemplate",
+    "rdfs:comment" : "Template for describing raw data from (bulk) RNA-sequencing",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:nucleicAcidSource"
+    }, {
+      "@id" : "bts:specimenPreparationMethod"
+    }, {
+      "@id" : "bts:specimenType"
+    }, {
+      "@id" : "bts:runType"
+    }, {
+      "@id" : "bts:libraryStrand"
+    }, {
+      "@id" : "bts:libraryPrep"
+    }, {
+      "@id" : "bts:libraryPreparationMethod"
+    }, {
+      "@id" : "bts:readPair"
+    }, {
+      "@id" : "bts:readLength"
+    }, {
+      "@id" : "bts:readDepth"
+    }, {
+      "@id" : "bts:targetDepth"
+    }, {
+      "@id" : "bts:batchID"
+    } ],
+    "sms:displayName" : "RNASeqTemplate"
+  }, {
+    "rdfs:subClassOf" : [ ],
+    "@id" : "bts:Template",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : null,
+    "rdfs:label" : "Template",
+    "rdfs:comment" : "A collection of fields representing some entity.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ ],
+    "sms:displayName" : "Template"
+  }, {
+    "rdfs:subClassOf" : [ ],
+    "@id" : "bts:BiospecimenTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "BiospecimenTemplate",
+    "rdfs:comment" : "Specimen-level data, whether from human or animal.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:bodySite"
+    }, {
+      "@id" : "bts:experimentalCondition"
+    } ],
+    "sms:displayName" : "BiospecimenTemplate"
+  }, {
+    "rdfs:subClassOf" : [ ],
+    "@id" : "bts:PartialTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : null,
+    "rdfs:label" : "PartialTemplate",
+    "rdfs:comment" : "A template for collecting a subset of contextual data; not intended to be a standalone template but rather a subdocument.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ ],
+    "sms:displayName" : "PartialTemplate"
+  }, {
+    "rdfs:subClassOf" : [ ],
+    "@id" : "bts:PortalStudy",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : null,
+    "rdfs:label" : "PortalStudy",
+    "rdfs:comment" : "A scientific project of some planned duration with PIs and key contributors, specific research topics, and potential publication/data/other outputs.  A study is often represented as a Synapse project and so is also referred to as \"project\". The study schema here is specifically for studies listed on the NF Portal at https://nf.synapse.org/Explore/Studies.\n",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ ],
+    "sms:displayName" : "PortalStudy"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BiologicalAssayDataTemplate"
+    } ],
+    "@id" : "bts:ImagingAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "ImagingAssayTemplate",
+    "rdfs:comment" : "General template for describing imaging data.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:assayTarget"
+    }, {
+      "@id" : "bts:auxiliaryAsset"
+    } ],
+    "sms:displayName" : "ImagingAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:GenomicsAssayTemplate"
+    } ],
+    "@id" : "bts:GenomicsAssayTemplateExtended",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "GenomicsAssayTemplateExtended",
+    "rdfs:comment" : "Genomics assay template but with additional experiment data.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:nucleicAcidSource"
+    }, {
+      "@id" : "bts:specimenPreparationMethod"
+    }, {
+      "@id" : "bts:specimenType"
+    }, {
+      "@id" : "bts:runType"
+    }, {
+      "@id" : "bts:libraryStrand"
+    }, {
+      "@id" : "bts:libraryPrep"
+    }, {
+      "@id" : "bts:libraryPreparationMethod"
+    }, {
+      "@id" : "bts:readPair"
+    }, {
+      "@id" : "bts:readLength"
+    }, {
+      "@id" : "bts:readDepth"
+    }, {
+      "@id" : "bts:targetDepth"
+    }, {
+      "@id" : "bts:batchID"
+    }, {
+      "@id" : "bts:experimentalCondition"
+    }, {
+      "@id" : "bts:experimentalTimepoint"
+    }, {
+      "@id" : "bts:timepointUnit"
+    }, {
+      "@id" : "bts:genePerturbed"
+    }, {
+      "@id" : "bts:genePerturbationTechnology"
+    }, {
+      "@id" : "bts:genePerturbationType"
+    } ],
+    "sms:displayName" : "GenomicsAssayTemplateExtended"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:ProteinAssayTemplate"
+    } ],
+    "@id" : "bts:ProteinArrayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "ProteinArrayTemplate",
+    "rdfs:comment" : "Template for array- and immuno-based proteomics data.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:proteinExtractSource"
+    }, {
+      "@id" : "bts:antibodyID"
+    } ],
+    "sms:displayName" : "ProteinArrayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:GenomicsAssayTemplate"
+    } ],
+    "@id" : "bts:PdxGenomicsAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "PdxGenomicsAssayTemplate",
+    "rdfs:comment" : "Raw genomics data from patient-derived xenograft (PDX) experiment, with additional PDX-relevant metadata.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:nucleicAcidSource"
+    }, {
+      "@id" : "bts:specimenPreparationMethod"
+    }, {
+      "@id" : "bts:specimenType"
+    }, {
+      "@id" : "bts:runType"
+    }, {
+      "@id" : "bts:libraryStrand"
+    }, {
+      "@id" : "bts:libraryPrep"
+    }, {
+      "@id" : "bts:libraryPreparationMethod"
+    }, {
+      "@id" : "bts:readPair"
+    }, {
+      "@id" : "bts:readLength"
+    }, {
+      "@id" : "bts:readDepth"
+    }, {
+      "@id" : "bts:targetDepth"
+    }, {
+      "@id" : "bts:batchID"
+    }, {
+      "@id" : "bts:transplantationType"
+    }, {
+      "@id" : "bts:transplantationRecipientSpecies"
+    }, {
+      "@id" : "bts:transplantationRecipientTissue"
+    }, {
+      "@id" : "bts:experimentalCondition"
+    }, {
+      "@id" : "bts:experimentalTimepoint"
+    }, {
+      "@id" : "bts:timepointUnit"
+    } ],
+    "sms:displayName" : "PdxGenomicsAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:MaterialScienceAssayTemplate"
+    } ],
+    "@id" : "bts:LightScatteringAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "LightScatteringAssayTemplate",
+    "rdfs:comment" : "Template for dynamic or static light scattering data adapted from ISA-TAB-Nano specs.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:materialType"
+    }, {
+      "@id" : "bts:concentrationMaterial"
+    }, {
+      "@id" : "bts:concentrationMaterialUnit"
+    }, {
+      "@id" : "bts:concentrationNaCl"
+    }, {
+      "@id" : "bts:concentrationNaClUnit"
+    }, {
+      "@id" : "bts:pH"
+    } ],
+    "sms:displayName" : "LightScatteringAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BiologicalAssayDataTemplate"
+    } ],
+    "@id" : "bts:ProcessedAlignedReadsTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "ProcessedAlignedReadsTemplate",
+    "rdfs:comment" : "Template for describing aligned reads (e.g. BAM/CRAM files) from a sequencing assay. The QC meta are extracted from samtools stats when available and are the same metrics preferred by GDC. \n",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:genomicReference"
+    }, {
+      "@id" : "bts:genomicReferenceLink"
+    }, {
+      "@id" : "bts:averageInsertSize"
+    }, {
+      "@id" : "bts:averageReadLength"
+    }, {
+      "@id" : "bts:averageBaseQuality"
+    }, {
+      "@id" : "bts:pairsOnDifferentChr"
+    }, {
+      "@id" : "bts:readsDuplicatedPercent"
+    }, {
+      "@id" : "bts:readsMappedPercent"
+    }, {
+      "@id" : "bts:meanCoverage"
+    }, {
+      "@id" : "bts:proportionCoverage10x"
+    }, {
+      "@id" : "bts:proportionCoverage30x"
+    }, {
+      "@id" : "bts:readDepth"
+    }, {
+      "@id" : "bts:totalReads"
+    }, {
+      "@id" : "bts:workflow"
+    }, {
+      "@id" : "bts:workflowLink"
+    }, {
+      "@id" : "bts:auxiliaryAsset"
+    } ],
+    "sms:displayName" : "ProcessedAlignedReadsTemplate"
+  }, {
+    "rdfs:subClassOf" : [ ],
+    "@id" : "bts:HumanCohortTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "HumanCohortTemplate",
+    "rdfs:comment" : "Data of biosamples from human patients. Adapted from Table 2 of http://nrs.harvard.edu/urn-3:HUL.InstRepos:32725809. This template should be used when biosamples are from NF patients to provides a more valuable characterization and make additional gene-phenotype insights possible.\n",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:diagnosisAgeGroup"
+    }, {
+      "@id" : "bts:inheritance"
+    }, {
+      "@id" : "bts:mosaicism"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:germlineMutationIndicator"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:vitalStatus"
+    }, {
+      "@id" : "bts:WHOPerformanceStatus"
+    }, {
+      "@id" : "bts:painStatus"
+    }, {
+      "@id" : "bts:tumorTreatmentStatus"
+    }, {
+      "@id" : "bts:cafeaulaitMacules"
+    }, {
+      "@id" : "bts:skinFoldFreckling"
+    }, {
+      "@id" : "bts:IrisLischNodules"
+    }, {
+      "@id" : "bts:dermalNeurofibromas"
+    }, {
+      "@id" : "bts:subcutaneousNodularNeurofibromas"
+    }, {
+      "@id" : "bts:diffuseDermalNeurofibromas"
+    }, {
+      "@id" : "bts:spinalNeurofibromas"
+    }, {
+      "@id" : "bts:plexiformNeurofibromas"
+    }, {
+      "@id" : "bts:opticGlioma"
+    }, {
+      "@id" : "bts:heartDefect"
+    }, {
+      "@id" : "bts:vascularDisease"
+    }, {
+      "@id" : "bts:pubertyOnset"
+    }, {
+      "@id" : "bts:stature"
+    }, {
+      "@id" : "bts:peripheralNeuropathy"
+    }, {
+      "@id" : "bts:aqueductalStenosis"
+    }, {
+      "@id" : "bts:longBoneDysplasia"
+    }, {
+      "@id" : "bts:sphenoidDysplasia"
+    }, {
+      "@id" : "bts:scoliosis"
+    }, {
+      "@id" : "bts:intellectualDisability"
+    }, {
+      "@id" : "bts:learningDisability"
+    }, {
+      "@id" : "bts:attentionDeficitDisorder"
+    }, {
+      "@id" : "bts:pheochromocytoma"
+    }, {
+      "@id" : "bts:glomusTumor"
+    }, {
+      "@id" : "bts:MPNST"
+    }, {
+      "@id" : "bts:nonopticGlioma"
+    }, {
+      "@id" : "bts:GIST"
+    }, {
+      "@id" : "bts:leukemia"
+    }, {
+      "@id" : "bts:breastCancer"
+    }, {
+      "@id" : "bts:otherTumors"
+    }, {
+      "@id" : "bts:vestibularSchwannoma"
+    }, {
+      "@id" : "bts:meningioma"
+    }, {
+      "@id" : "bts:gliomaOrEpendymoma"
+    }, {
+      "@id" : "bts:spinalSchwannoma"
+    }, {
+      "@id" : "bts:dermalSchwannoma"
+    }, {
+      "@id" : "bts:nonvestibularCranialSchwannoma"
+    }, {
+      "@id" : "bts:lenticularopacity"
+    }, {
+      "@id" : "bts:nonvestibularSchwannomas"
+    }, {
+      "@id" : "bts:numberOfSchwannomas"
+    } ],
+    "sms:displayName" : "HumanCohortTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:Template"
+    } ],
+    "@id" : "bts:ProtocolTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "ProtocolTemplate",
+    "rdfs:comment" : "Template for describing a protocol document.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:title"
+    }, {
+      "@id" : "bts:author"
+    }, {
+      "@id" : "bts:citation"
+    }, {
+      "@id" : "bts:license"
+    }, {
+      "@id" : "bts:protocolAssay"
+    }, {
+      "@id" : "bts:protocolPurpose"
+    }, {
+      "@id" : "bts:sampleType"
+    }, {
+      "@id" : "bts:comments"
+    } ],
+    "sms:displayName" : "ProtocolTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BulkSequencingAssayTemplate"
+    } ],
+    "@id" : "bts:EpigenomiscAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "EpigenomiscAssayTemplate",
+    "rdfs:comment" : "Template for describing raw data from epigenetics sequencing assays such as bisulfite sequencing.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:nucleicAcidSource"
+    }, {
+      "@id" : "bts:specimenPreparationMethod"
+    }, {
+      "@id" : "bts:specimenType"
+    }, {
+      "@id" : "bts:runType"
+    }, {
+      "@id" : "bts:libraryStrand"
+    }, {
+      "@id" : "bts:libraryPrep"
+    }, {
+      "@id" : "bts:libraryPreparationMethod"
+    }, {
+      "@id" : "bts:readPair"
+    }, {
+      "@id" : "bts:readLength"
+    }, {
+      "@id" : "bts:readDepth"
+    }, {
+      "@id" : "bts:targetDepth"
+    }, {
+      "@id" : "bts:batchID"
+    }, {
+      "@id" : "bts:bisulfiteConversionKitID"
+    } ],
+    "sms:displayName" : "EpigenomiscAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BiologicalAssayDataTemplate"
+    } ],
+    "@id" : "bts:ProcessedExpressionTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "ProcessedExpressionTemplate",
+    "rdfs:comment" : "Template for quantified gene/protein expression data that are still represented as one file per sample.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:expressionUnit"
+    }, {
+      "@id" : "bts:workflow"
+    }, {
+      "@id" : "bts:workflowLink"
+    }, {
+      "@id" : "bts:auxiliaryAsset"
+    } ],
+    "sms:displayName" : "ProcessedExpressionTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:GeneticsAssayTemplate"
+    } ],
+    "@id" : "bts:GenomicsArrayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "GenomicsArrayTemplate",
+    "rdfs:comment" : "A template for describing raw data from array-based genomics/epigenomics, e.g. CEL files.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:nucleicAcidSource"
+    }, {
+      "@id" : "bts:specimenPreparationMethod"
+    }, {
+      "@id" : "bts:channel"
+    } ],
+    "sms:displayName" : "GenomicsArrayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:MassSpecAssayTemplate"
+    } ],
+    "@id" : "bts:ProteomicsAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "ProteomicsAssayTemplate",
+    "rdfs:comment" : "Alias to MassSpecAssayTemplate for backwards-compatibility.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:proteinExtractSource"
+    }, {
+      "@id" : "bts:dataCollectionMode"
+    } ],
+    "sms:displayName" : "ProteomicsAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BulkSequencingAssayTemplate"
+    } ],
+    "@id" : "bts:GenomicsAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "GenomicsAssayTemplate",
+    "rdfs:comment" : "Alias to BulkSequencingAssayTemplate, use for sequence data on a large scale when there is no template available that is more specific.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:nucleicAcidSource"
+    }, {
+      "@id" : "bts:specimenPreparationMethod"
+    }, {
+      "@id" : "bts:specimenType"
+    }, {
+      "@id" : "bts:runType"
+    }, {
+      "@id" : "bts:libraryStrand"
+    }, {
+      "@id" : "bts:libraryPrep"
+    }, {
+      "@id" : "bts:libraryPreparationMethod"
+    }, {
+      "@id" : "bts:readPair"
+    }, {
+      "@id" : "bts:readLength"
+    }, {
+      "@id" : "bts:readDepth"
+    }, {
+      "@id" : "bts:targetDepth"
+    }, {
+      "@id" : "bts:batchID"
+    } ],
+    "sms:displayName" : "GenomicsAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:Template"
+    } ],
+    "@id" : "bts:BiologicalAssayDataTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : null,
+    "rdfs:label" : "BiologicalAssayDataTemplate",
+    "rdfs:comment" : "A template defining basic metadata on deposited data artifacts (i.e. files) from experimental assays involving biosamples.  This is an abstract template; \"real\" template subclasses define additional properties appropriate for the type of data file (e.g. imaging vs sequencing).\n",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    } ],
+    "sms:displayName" : "BiologicalAssayDataTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BiologicalAssayDataTemplate"
+    } ],
+    "@id" : "bts:GeneticsAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "GeneticsAssayTemplate",
+    "rdfs:comment" : "Template for relatively raw data of RNA/DNA structure and expression.  This is an abstract template encapsulating data from low-throughput to high-throughput assays,  sequencing-based or non-sequencing based (e.g. microarrays, optical genome mapping).  In practice, data are more specifically typed and matched to one of the templates below.\n",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:nucleicAcidSource"
+    }, {
+      "@id" : "bts:specimenPreparationMethod"
+    } ],
+    "sms:displayName" : "GeneticsAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BulkSequencingAssayTemplate"
+    } ],
+    "@id" : "bts:WGSTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "WGSTemplate",
+    "rdfs:comment" : "Template for describing raw data from Whole Genome Sequencing (WGS)",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:nucleicAcidSource"
+    }, {
+      "@id" : "bts:specimenPreparationMethod"
+    }, {
+      "@id" : "bts:specimenType"
+    }, {
+      "@id" : "bts:runType"
+    }, {
+      "@id" : "bts:libraryStrand"
+    }, {
+      "@id" : "bts:libraryPrep"
+    }, {
+      "@id" : "bts:libraryPreparationMethod"
+    }, {
+      "@id" : "bts:readPair"
+    }, {
+      "@id" : "bts:readLength"
+    }, {
+      "@id" : "bts:readDepth"
+    }, {
+      "@id" : "bts:targetDepth"
+    }, {
+      "@id" : "bts:batchID"
+    } ],
+    "sms:displayName" : "WGSTemplate"
+  }, {
+    "rdfs:subClassOf" : [ ],
+    "@id" : "bts:ProcessedMergedDataTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "ProcessedMergedDataTemplate",
+    "rdfs:comment" : "Further processed data with multiple samples aggregated into one file. This may be also be known as level-4 data. Unlike level-2 and level-3 data, individual-level attributes such as age and sex are no longer surfaced on the data file directly.\n",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:workflow"
+    }, {
+      "@id" : "bts:workflowLink"
+    }, {
+      "@id" : "bts:auxiliaryAsset"
+    }, {
+      "@id" : "bts:assay"
+    } ],
+    "sms:displayName" : "ProcessedMergedDataTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:GeneticsAssayTemplate"
+    } ],
+    "@id" : "bts:ScSequencingAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "ScSequencingAssayTemplate",
+    "rdfs:comment" : "General template for raw RNA/DNA data, i.e. sequence data from a sequencing assay.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:nucleicAcidSource"
+    }, {
+      "@id" : "bts:specimenPreparationMethod"
+    }, {
+      "@id" : "bts:cellType"
+    }, {
+      "@id" : "bts:isCellLine"
+    }, {
+      "@id" : "bts:cellID"
+    }, {
+      "@id" : "bts:dissociationMethod"
+    }, {
+      "@id" : "bts:runType"
+    }, {
+      "@id" : "bts:libraryStrand"
+    }, {
+      "@id" : "bts:libraryPrep"
+    }, {
+      "@id" : "bts:libraryPreparationMethod"
+    }, {
+      "@id" : "bts:readPair"
+    }, {
+      "@id" : "bts:readLength"
+    }, {
+      "@id" : "bts:readDepth"
+    }, {
+      "@id" : "bts:targetDepth"
+    }, {
+      "@id" : "bts:batchID"
+    }, {
+      "@id" : "bts:auxiliaryAsset"
+    } ],
+    "sms:displayName" : "ScSequencingAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:PartialTemplate"
+    } ],
+    "@id" : "bts:UpdateMilestoneReport",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "UpdateMilestoneReport",
+    "rdfs:comment" : "Metadata template for updating milestone report values in NF studies -- currently a supported feature for NTAP and GFF.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:progressReportNumber"
+    } ],
+    "sms:displayName" : "UpdateMilestoneReport"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BiologicalAssayDataTemplate"
+    } ],
+    "@id" : "bts:PharmacokineticsAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "PharmacokineticsAssayTemplate",
+    "rdfs:comment" : "Generic template for describing data from a pharmacokinetics assay.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:compoundName"
+    }, {
+      "@id" : "bts:compoundDose"
+    }, {
+      "@id" : "bts:compoundDoseUnit"
+    }, {
+      "@id" : "bts:experimentalCondition"
+    }, {
+      "@id" : "bts:experimentalTimepoint"
+    }, {
+      "@id" : "bts:timepointUnit"
+    } ],
+    "sms:displayName" : "PharmacokineticsAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:GeneticsAssayTemplate"
+    } ],
+    "@id" : "bts:BulkSequencingAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "BulkSequencingAssayTemplate",
+    "rdfs:comment" : "General template for raw (level 1) RNA/DNA data, i.e. sequence data from a sequencing assay.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:nucleicAcidSource"
+    }, {
+      "@id" : "bts:specimenPreparationMethod"
+    }, {
+      "@id" : "bts:specimenType"
+    }, {
+      "@id" : "bts:runType"
+    }, {
+      "@id" : "bts:libraryStrand"
+    }, {
+      "@id" : "bts:libraryPrep"
+    }, {
+      "@id" : "bts:libraryPreparationMethod"
+    }, {
+      "@id" : "bts:readPair"
+    }, {
+      "@id" : "bts:readLength"
+    }, {
+      "@id" : "bts:readDepth"
+    }, {
+      "@id" : "bts:targetDepth"
+    }, {
+      "@id" : "bts:batchID"
+    } ],
+    "sms:displayName" : "BulkSequencingAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BiologicalAssayDataTemplate"
+    } ],
+    "@id" : "bts:ElectrophysiologyAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : null,
+    "rdfs:label" : "ElectrophysiologyAssayTemplate",
+    "rdfs:comment" : "Template for raw electrophysiology data (electrical recordings).",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:bodySite"
+    }, {
+      "@id" : "bts:cellType"
+    }, {
+      "@id" : "bts:recordingSource"
+    }, {
+      "@id" : "bts:experimentalTimepoint"
+    }, {
+      "@id" : "bts:timepointUnit"
+    }, {
+      "@id" : "bts:experimentalCondition"
+    }, {
+      "@id" : "bts:auxiliaryAsset"
+    } ],
+    "sms:displayName" : "ElectrophysiologyAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:ImagingAssayTemplate"
+    } ],
+    "@id" : "bts:MicroscopyAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "MicroscopyAssayTemplate",
+    "rdfs:comment" : "Template for data from a microscopy data.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:assayTarget"
+    }, {
+      "@id" : "bts:auxiliaryAsset"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:objective"
+    }, {
+      "@id" : "bts:nominalMagnification"
+    }, {
+      "@id" : "bts:lensAperture"
+    }, {
+      "@id" : "bts:workingDistance"
+    }, {
+      "@id" : "bts:workingDistanceUnit"
+    }, {
+      "@id" : "bts:immersion"
+    } ],
+    "sms:displayName" : "MicroscopyAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:MicroscopyAssayTemplate"
+    } ],
+    "@id" : "bts:ImmunoMicroscopyTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "ImmunoMicroscopyTemplate",
+    "rdfs:comment" : "Template for describing immunofluorescence or immunohistochemistry images.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:assayTarget"
+    }, {
+      "@id" : "bts:auxiliaryAsset"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:objective"
+    }, {
+      "@id" : "bts:nominalMagnification"
+    }, {
+      "@id" : "bts:lensAperture"
+    }, {
+      "@id" : "bts:workingDistance"
+    }, {
+      "@id" : "bts:workingDistanceUnit"
+    }, {
+      "@id" : "bts:immersion"
+    }, {
+      "@id" : "bts:antibodyID"
+    } ],
+    "sms:displayName" : "ImmunoMicroscopyTemplate"
+  }, {
+    "rdfs:subClassOf" : [ ],
+    "@id" : "bts:AnimalIndividualTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "AnimalIndividualTemplate",
+    "rdfs:comment" : "Template for non-human individual-level data.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:diagnosisAgeGroup"
+    }, {
+      "@id" : "bts:inheritance"
+    }, {
+      "@id" : "bts:mosaicism"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:germlineMutation"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:modelSystemName"
+    } ],
+    "sms:displayName" : "AnimalIndividualTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BiologicalAssayDataTemplate"
+    } ],
+    "@id" : "bts:PlateBasedReporterAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "PlateBasedReporterAssayTemplate",
+    "rdfs:comment" : "Generic template for describing data from a plate-based reporter assay.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:assayTarget"
+    }, {
+      "@id" : "bts:compoundName"
+    }, {
+      "@id" : "bts:compoundDose"
+    }, {
+      "@id" : "bts:compoundDoseUnit"
+    }, {
+      "@id" : "bts:experimentalCondition"
+    }, {
+      "@id" : "bts:experimentalTimepoint"
+    }, {
+      "@id" : "bts:timepointUnit"
+    }, {
+      "@id" : "bts:reporterGene"
+    }, {
+      "@id" : "bts:reporterSubstance"
+    } ],
+    "sms:displayName" : "PlateBasedReporterAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:ImagingAssayTemplate"
+    } ],
+    "@id" : "bts:MRIAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "MRIAssayTemplate",
+    "rdfs:comment" : "Template for describing MRI data.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:assayTarget"
+    }, {
+      "@id" : "bts:auxiliaryAsset"
+    }, {
+      "@id" : "bts:bodySite"
+    }, {
+      "@id" : "bts:MRISequence"
+    }, {
+      "@id" : "bts:experimentalCondition"
+    }, {
+      "@id" : "bts:experimentalTimepoint"
+    }, {
+      "@id" : "bts:timepointUnit"
+    } ],
+    "sms:displayName" : "MRIAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BulkSequencingAssayTemplate"
+    } ],
+    "@id" : "bts:WESTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "WESTemplate",
+    "rdfs:comment" : "Template for describing raw data from Whole Exome Sequencing (WES/WXS)",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:nucleicAcidSource"
+    }, {
+      "@id" : "bts:specimenPreparationMethod"
+    }, {
+      "@id" : "bts:specimenType"
+    }, {
+      "@id" : "bts:runType"
+    }, {
+      "@id" : "bts:libraryStrand"
+    }, {
+      "@id" : "bts:libraryPrep"
+    }, {
+      "@id" : "bts:libraryPreparationMethod"
+    }, {
+      "@id" : "bts:readPair"
+    }, {
+      "@id" : "bts:readLength"
+    }, {
+      "@id" : "bts:readDepth"
+    }, {
+      "@id" : "bts:targetDepth"
+    }, {
+      "@id" : "bts:batchID"
+    }, {
+      "@id" : "bts:targetCaptureKitID"
+    } ],
+    "sms:displayName" : "WESTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:Template"
+    } ],
+    "@id" : "bts:SourceCodeTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "SourceCodeTemplate",
+    "rdfs:comment" : "Template for describing scripts or software code.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:title"
+    }, {
+      "@id" : "bts:author"
+    }, {
+      "@id" : "bts:citation"
+    }, {
+      "@id" : "bts:license"
+    }, {
+      "@id" : "bts:programmingLanguage"
+    }, {
+      "@id" : "bts:runtimePlatform"
+    }, {
+      "@id" : "bts:documentation"
+    } ],
+    "sms:displayName" : "SourceCodeTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:EpigenomiscAssayTemplate"
+    } ],
+    "@id" : "bts:EpigeneticsAssayTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "EpigeneticsAssayTemplate",
+    "rdfs:comment" : "Alias for EpigenomiscAssayTemplate for backwards-compatibility.",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:parentSpecimenID"
+    }, {
+      "@id" : "bts:specimenID"
+    }, {
+      "@id" : "bts:aliquotID"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:nucleicAcidSource"
+    }, {
+      "@id" : "bts:specimenPreparationMethod"
+    }, {
+      "@id" : "bts:specimenType"
+    }, {
+      "@id" : "bts:runType"
+    }, {
+      "@id" : "bts:libraryStrand"
+    }, {
+      "@id" : "bts:libraryPrep"
+    }, {
+      "@id" : "bts:libraryPreparationMethod"
+    }, {
+      "@id" : "bts:readPair"
+    }, {
+      "@id" : "bts:readLength"
+    }, {
+      "@id" : "bts:readDepth"
+    }, {
+      "@id" : "bts:targetDepth"
+    }, {
+      "@id" : "bts:batchID"
+    }, {
+      "@id" : "bts:bisulfiteConversionKitID"
+    } ],
+    "sms:displayName" : "EpigeneticsAssayTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BiologicalAssayDataTemplate"
+    } ],
+    "@id" : "bts:ProcessedVariantCallsTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "ProcessedVariantCallsTemplate",
+    "rdfs:comment" : "Template for describing either simple germline/somatic variant calls output data (VCF/MAF) as well as structural variants (e.g. CNVs).",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:isFilteredReads"
+    }, {
+      "@id" : "bts:workflow"
+    }, {
+      "@id" : "bts:workflowLink"
+    }, {
+      "@id" : "bts:auxiliaryAsset"
+    } ],
+    "sms:displayName" : "ProcessedVariantCallsTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:Template"
+    } ],
+    "@id" : "bts:NonBiologicalAssayDataTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : null,
+    "rdfs:label" : "NonBiologicalAssayDataTemplate",
+    "rdfs:comment" : "A template for describing deposited data artifacts (i.e. files) from an experimental assay that main involves non-biological samples.   \n",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    } ],
+    "sms:displayName" : "NonBiologicalAssayDataTemplate"
+  }, {
+    "rdfs:subClassOf" : [ ],
+    "@id" : "bts:PortalDataset",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : null,
+    "rdfs:label" : "PortalDataset",
+    "rdfs:comment" : "A slightly more specialized dataset concept intended for the specific scope of the NF Portal; see https://nf.synapse.org/Explore/Datasets. \n",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ ],
+    "sms:displayName" : "PortalDataset"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:BiologicalAssayDataTemplate"
+    } ],
+    "@id" : "bts:FlowCytometryTemplate",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : "",
+    "rdfs:label" : "FlowCytometryTemplate",
+    "rdfs:comment" : "Template for flow cytometry assay",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:Component"
+    }, {
+      "@id" : "bts:Filename"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:dataType"
+    }, {
+      "@id" : "bts:dataSubtype"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:individualID"
+    }, {
+      "@id" : "bts:species"
+    }, {
+      "@id" : "bts:sex"
+    }, {
+      "@id" : "bts:age"
+    }, {
+      "@id" : "bts:ageUnit"
+    }, {
+      "@id" : "bts:diagnosis"
+    }, {
+      "@id" : "bts:nf1Genotype"
+    }, {
+      "@id" : "bts:nf2Genotype"
+    }, {
+      "@id" : "bts:tumorType"
+    }, {
+      "@id" : "bts:modelSystemName"
+    }, {
+      "@id" : "bts:organ"
+    }, {
+      "@id" : "bts:comments"
+    }, {
+      "@id" : "bts:platform"
+    }, {
+      "@id" : "bts:cellType"
+    }, {
+      "@id" : "bts:auxiliaryAsset"
+    } ],
+    "sms:displayName" : "FlowCytometryTemplate"
+  }, {
+    "rdfs:subClassOf" : [ {
+      "@id" : "bts:Template"
+    } ],
+    "@id" : "bts:WorkflowReport",
+    "schema:isPartOf" : {
+      "@id" : "http://schema.biothings.io/"
+    },
+    "sms:required" : "sms:false",
+    "sms:requiresComponent" : null,
+    "rdfs:label" : "WorkflowReport",
+    "rdfs:comment" : "Template used for miscellaneous workflow reports and accessory files",
+    "@type" : "rdfs:Class",
+    "sms:requiresDependency" : [ {
+      "@id" : "bts:resourceType"
+    }, {
+      "@id" : "bts:assay"
+    }, {
+      "@id" : "bts:fileFormat"
+    }, {
+      "@id" : "bts:relatedDataset"
+    }, {
+      "@id" : "bts:workflow"
+    }, {
+      "@id" : "bts:workflowLink"
+    } ],
+    "sms:displayName" : "WorkflowReport"
+  }, {
     "rdfs:subClassOf" : [ ],
     "@id" : "bts:institution",
     "schema:isPartOf" : {
@@ -5808,3688 +9490,6 @@
     },
     "sms:displayName" : "studyLeads",
     "sms:required" : "sms:true"
-  }, {
-    "@id" : "bts:BodyPartEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "BodyPartEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "BodyPartEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:UnknownEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "UnknownEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "UnknownEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:SpecimenPreparationMethodEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "SpecimenPreparationMethodEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "SpecimenPreparationMethodEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:FileFormatEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "FileFormatEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "FileFormatEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:MultipleImagingDiagnosisEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "Enumerations describing the manifestation of tumors confirmed via imaging with one or multiple sites being the most relevant result.",
-    "rdfs:label" : "MultipleImagingDiagnosisEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "MultipleImagingDiagnosisEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:SexEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "SexEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "SexEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:MRISequenceEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "MRISequenceEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "MRISequenceEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:AgeGroupEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "AgeGroupEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "AgeGroupEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:TumorTreatmentEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "TumorTreatmentEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "TumorTreatmentEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:PlatformEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "PlatformEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "PlatformEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:NF1Variant",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "NF1Variant",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "NF1Variant",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:GenePerturbationEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "GenePerturbationEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "GenePerturbationEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:TestSummaryEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "TestSummaryEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "TestSummaryEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:SpinalNeuromaManifestationEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "Enumerations describing the manifestation of spinal neurofibromas, combining information on presence and the cervical locations.",
-    "rdfs:label" : "SpinalNeuromaManifestationEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "SpinalNeuromaManifestationEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:WorkflowEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "WorkflowEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "WorkflowEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:BooleanEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "Boolean data as Yes/No enums",
-    "rdfs:label" : "BooleanEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "BooleanEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:PubertyOnsetEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "PubertyOnsetEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "PubertyOnsetEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:GenePerturbationMethodEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "GenePerturbationMethodEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "GenePerturbationMethodEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:Data",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "Data",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "Data",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:PlexiformNeurofibromaManifestationEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "Enumerations describing the manifestation of plexiform neurofibromas, combining information on presence and the certainty via MRI imaging technique.",
-    "rdfs:label" : "PlexiformNeurofibromaManifestationEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "PlexiformNeurofibromaManifestationEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:BinaryImagingDiagnosisEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "Enumerations describing the manifestation of tumors confirmed via imaging with mainly absent or present being the most relevant result.",
-    "rdfs:label" : "BinaryImagingDiagnosisEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "BinaryImagingDiagnosisEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:SpeciesEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "SpeciesEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "SpeciesEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:DiagnosisEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "DiagnosisEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "DiagnosisEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:ProteinExtractSourceEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "ProteinExtractSourceEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "ProteinExtractSourceEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:VitalStatusEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "VitalStatusEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "VitalStatusEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:MosaicismEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "MosaicismEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "MosaicismEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:WorkingDistanceUnitEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "WorkingDistanceUnitEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "WorkingDistanceUnitEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:StrandednessEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "StrandednessEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "StrandednessEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:OrganismSubstance",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "This preferred root in the UBERON ontology is meant to cover organism-produced substances (bodily secretions and excreta) commonly used as assay specimens.",
-    "rdfs:label" : "OrganismSubstance",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "OrganismSubstance",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:BiologicalProcess",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "BiologicalProcess",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "BiologicalProcess",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:ExpressionUnitEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "Quantification units for gene expression.",
-    "rdfs:label" : "ExpressionUnitEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "ExpressionUnitEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:OrganEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "OrganEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "OrganEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:Tumor",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "Tumor",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "Tumor",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:WHOPerformanceStatusScores",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "https://www.ncbi.nlm.nih.gov/books/NBK97482/",
-    "rdfs:label" : "WHOPerformanceStatusScores",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "WHOPerformanceStatusScores",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:ConcentrationUnit",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "ConcentrationUnit",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "ConcentrationUnit",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:NucleicAcidSourceEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "NucleicAcidSourceEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "NucleicAcidSourceEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:ReadPairOrientationEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "ReadPairOrientationEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "ReadPairOrientationEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:LateralManifestationEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "Enumerations describing the manifestation of tumors confirmed via imaging (MRI or other), where lateral information is most relevant.",
-    "rdfs:label" : "LateralManifestationEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "LateralManifestationEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:LibraryPrepEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "LibraryPrepEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "LibraryPrepEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:Percentiles-2SD",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "Enumerations corresponding to 3 bins using 2 standard deviations as a cutoff.",
-    "rdfs:label" : "Percentiles-2SD",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "Percentiles-2SD",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:Tissue",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "Tissue is a group of cells that have similar structure and that function together as a unit.",
-    "rdfs:label" : "Tissue",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "Tissue",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:DataSubtype",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "DataSubtype",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "DataSubtype",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:LibraryPreparationMethodEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "LibraryPreparationMethodEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "LibraryPreparationMethodEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:StudyStatusEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "StudyStatusEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "StudyStatusEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:Metadata",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "Data that provides information about other data",
-    "rdfs:label" : "Metadata",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "Metadata",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:DiseaseFocusEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "DiseaseFocusEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "DiseaseFocusEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:ChannelEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "ChannelEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "ChannelEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:FundingAgencyEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "FundingAgencyEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "FundingAgencyEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:Cell",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "Cell",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "Cell",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:GenomicReferenceEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "GenomicReferenceEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "GenomicReferenceEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:Genotype",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "Genotype",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "Genotype",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:DrugScreen",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "This is a subset of Assay enum above.",
-    "rdfs:label" : "DrugScreen",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "DrugScreen",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:DissociationMethodEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "DissociationMethodEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "DissociationMethodEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:TimeUnit",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "TimeUnit",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "TimeUnit",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:Measurement",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "Measurement",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "Measurement",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:Material",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "Material",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "Material",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:ManifestationEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "ManifestationEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "ManifestationEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:SchwannomaManifestationEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "Enumerations describing the manifestation of schwannomas.",
-    "rdfs:label" : "SchwannomaManifestationEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "SchwannomaManifestationEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:OpticGliomaManifestationEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "Enumerations describing the manifestation of optic gliomas, combining information on presence, symptoms, and treatment.",
-    "rdfs:label" : "OpticGliomaManifestationEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "OpticGliomaManifestationEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:TransplantationType",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "TransplantationType",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "TransplantationType",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:RunTypeEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "RunTypeEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "RunTypeEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:NotApplicableEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "NotApplicableEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "NotApplicableEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:CellLineModel",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "CellLineModel",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "CellLineModel",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:Resource",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "Resource",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "Resource",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:MouseModel",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "MouseModel",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "MouseModel",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:AssayEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "AssayEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "AssayEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:CuratedDataEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "CuratedDataEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "CuratedDataEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:NonvestibularSchwannomaManifestationEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "NonvestibularSchwannomaManifestationEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "NonvestibularSchwannomaManifestationEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:DataStatusEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "DataStatusEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "DataStatusEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:Institution",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "Institution",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "Institution",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:ReadStrandOriginEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "ReadStrandOriginEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "ReadStrandOriginEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:PainEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "PainEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "PainEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:License",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "License attached to the data. If indicates UNKNOWN or RESTRICTED-USE, data may not be used without further contact for terms.",
-    "rdfs:label" : "License",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "License",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:PresenceEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "Enumeration for binary + unknown for very basic classification of a manifestation in clinical context.",
-    "rdfs:label" : "PresenceEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "PresenceEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:NeurofibromaManifestationEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "Enumerations describing how neurofibromas can manifest more generally.",
-    "rdfs:label" : "NeurofibromaManifestationEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "NeurofibromaManifestationEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:InheritanceEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "InheritanceEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "InheritanceEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:AccessTypeEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "AccessTypeEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "AccessTypeEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "@id" : "bts:GenePerturbationTechnologyEnum",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "TBD",
-    "rdfs:label" : "GenePerturbationTechnologyEnum",
-    "rdfs:subClassOf" : [ ],
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:displayName" : "GenePerturbationTechnologyEnum",
-    "sms:required" : "sms:false"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:ProteinAssayTemplate"
-    } ],
-    "@id" : "bts:MassSpecAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "MassSpecAssayTemplate",
-    "rdfs:comment" : "Template for raw mass spec-based proteomics data.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:proteinExtractSource"
-    }, {
-      "@id" : "bts:dataCollectionMode"
-    } ],
-    "sms:displayName" : "MassSpecAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BiologicalAssayDataTemplate"
-    } ],
-    "@id" : "bts:ClinicalAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "ClinicalAssayTemplate",
-    "rdfs:comment" : "General template for typically tabular **individual-level** data. This can include repeated measures and a drug treatment context.\n",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:experimentalFactor"
-    }, {
-      "@id" : "bts:experimentalCondition"
-    }, {
-      "@id" : "bts:timepointUnit"
-    }, {
-      "@id" : "bts:compoundName"
-    }, {
-      "@id" : "bts:compoundDose"
-    }, {
-      "@id" : "bts:compoundDoseUnit"
-    } ],
-    "sms:displayName" : "ClinicalAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:ScSequencingAssayTemplate"
-    } ],
-    "@id" : "bts:ScRNASeqTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "ScRNASeqTemplate",
-    "rdfs:comment" : "Template for describing raw data from single-cell RNA-seq.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:nucleicAcidSource"
-    }, {
-      "@id" : "bts:specimenPreparationMethod"
-    }, {
-      "@id" : "bts:cellType"
-    }, {
-      "@id" : "bts:isCellLine"
-    }, {
-      "@id" : "bts:cellID"
-    }, {
-      "@id" : "bts:dissociationMethod"
-    }, {
-      "@id" : "bts:runType"
-    }, {
-      "@id" : "bts:libraryStrand"
-    }, {
-      "@id" : "bts:libraryPrep"
-    }, {
-      "@id" : "bts:libraryPreparationMethod"
-    }, {
-      "@id" : "bts:readPair"
-    }, {
-      "@id" : "bts:readLength"
-    }, {
-      "@id" : "bts:readDepth"
-    }, {
-      "@id" : "bts:targetDepth"
-    }, {
-      "@id" : "bts:batchID"
-    }, {
-      "@id" : "bts:auxiliaryAsset"
-    } ],
-    "sms:displayName" : "ScRNASeqTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BiologicalAssayDataTemplate"
-    } ],
-    "@id" : "bts:ProteinAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "ProteinAssayTemplate",
-    "rdfs:comment" : "Abstract template for data from some assay of protein structure and function. Data should be instantiated with more specific template.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:proteinExtractSource"
-    } ],
-    "sms:displayName" : "ProteinAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BiologicalAssayDataTemplate"
-    } ],
-    "@id" : "bts:GeneralMeasureDataTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "GeneralMeasureDataTemplate",
-    "rdfs:comment" : "General template for data in tabular form that aggregates tissue-level or cellular-level data.\n",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:experimentalFactor"
-    }, {
-      "@id" : "bts:experimentalCondition"
-    }, {
-      "@id" : "bts:experimentalTimepoint"
-    }, {
-      "@id" : "bts:timepointUnit"
-    }, {
-      "@id" : "bts:compoundName"
-    }, {
-      "@id" : "bts:compoundDose"
-    }, {
-      "@id" : "bts:compoundDoseUnit"
-    }, {
-      "@id" : "bts:genePerturbed"
-    }, {
-      "@id" : "bts:genePerturbationType"
-    }, {
-      "@id" : "bts:genePerturbationTechnology"
-    } ],
-    "sms:displayName" : "GeneralMeasureDataTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:NonBiologicalAssayDataTemplate"
-    } ],
-    "@id" : "bts:MaterialScienceAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "MaterialScienceAssayTemplate",
-    "rdfs:comment" : "General template for describing data for a materials science assay.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:materialType"
-    }, {
-      "@id" : "bts:concentrationMaterial"
-    }, {
-      "@id" : "bts:concentrationMaterialUnit"
-    }, {
-      "@id" : "bts:concentrationNaCl"
-    }, {
-      "@id" : "bts:concentrationNaClUnit"
-    } ],
-    "sms:displayName" : "MaterialScienceAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BulkSequencingAssayTemplate"
-    } ],
-    "@id" : "bts:RNASeqTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "RNASeqTemplate",
-    "rdfs:comment" : "Template for describing raw data from (bulk) RNA-sequencing",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:nucleicAcidSource"
-    }, {
-      "@id" : "bts:specimenPreparationMethod"
-    }, {
-      "@id" : "bts:specimenType"
-    }, {
-      "@id" : "bts:runType"
-    }, {
-      "@id" : "bts:libraryStrand"
-    }, {
-      "@id" : "bts:libraryPrep"
-    }, {
-      "@id" : "bts:libraryPreparationMethod"
-    }, {
-      "@id" : "bts:readPair"
-    }, {
-      "@id" : "bts:readLength"
-    }, {
-      "@id" : "bts:readDepth"
-    }, {
-      "@id" : "bts:targetDepth"
-    }, {
-      "@id" : "bts:batchID"
-    } ],
-    "sms:displayName" : "RNASeqTemplate"
-  }, {
-    "rdfs:subClassOf" : [ ],
-    "@id" : "bts:Template",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : null,
-    "rdfs:label" : "Template",
-    "rdfs:comment" : "A collection of fields representing some entity.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ ],
-    "sms:displayName" : "Template"
-  }, {
-    "rdfs:subClassOf" : [ ],
-    "@id" : "bts:BiospecimenTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "BiospecimenTemplate",
-    "rdfs:comment" : "Specimen-level data, whether from human or animal.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:bodySite"
-    }, {
-      "@id" : "bts:experimentalCondition"
-    } ],
-    "sms:displayName" : "BiospecimenTemplate"
-  }, {
-    "rdfs:subClassOf" : [ ],
-    "@id" : "bts:PartialTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : null,
-    "rdfs:label" : "PartialTemplate",
-    "rdfs:comment" : "A template for collecting a subset of contextual data; not intended to be a standalone template but rather a subdocument.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ ],
-    "sms:displayName" : "PartialTemplate"
-  }, {
-    "rdfs:subClassOf" : [ ],
-    "@id" : "bts:PortalStudy",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : null,
-    "rdfs:label" : "PortalStudy",
-    "rdfs:comment" : "A scientific project of some planned duration with PIs and key contributors, specific research topics, and potential publication/data/other outputs.  A study is often represented as a Synapse project and so is also referred to as \"project\". The study schema here is specifically for studies listed on the NF Portal at https://nf.synapse.org/Explore/Studies.\n",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ ],
-    "sms:displayName" : "PortalStudy"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BiologicalAssayDataTemplate"
-    } ],
-    "@id" : "bts:ImagingAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "ImagingAssayTemplate",
-    "rdfs:comment" : "General template for describing imaging data.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:assayTarget"
-    }, {
-      "@id" : "bts:auxiliaryAsset"
-    } ],
-    "sms:displayName" : "ImagingAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:GenomicsAssayTemplate"
-    } ],
-    "@id" : "bts:GenomicsAssayTemplateExtended",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "GenomicsAssayTemplateExtended",
-    "rdfs:comment" : "Genomics assay template but with additional experiment data.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:nucleicAcidSource"
-    }, {
-      "@id" : "bts:specimenPreparationMethod"
-    }, {
-      "@id" : "bts:specimenType"
-    }, {
-      "@id" : "bts:runType"
-    }, {
-      "@id" : "bts:libraryStrand"
-    }, {
-      "@id" : "bts:libraryPrep"
-    }, {
-      "@id" : "bts:libraryPreparationMethod"
-    }, {
-      "@id" : "bts:readPair"
-    }, {
-      "@id" : "bts:readLength"
-    }, {
-      "@id" : "bts:readDepth"
-    }, {
-      "@id" : "bts:targetDepth"
-    }, {
-      "@id" : "bts:batchID"
-    }, {
-      "@id" : "bts:experimentalCondition"
-    }, {
-      "@id" : "bts:experimentalTimepoint"
-    }, {
-      "@id" : "bts:timepointUnit"
-    }, {
-      "@id" : "bts:genePerturbed"
-    }, {
-      "@id" : "bts:genePerturbationTechnology"
-    }, {
-      "@id" : "bts:genePerturbationType"
-    } ],
-    "sms:displayName" : "GenomicsAssayTemplateExtended"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:ProteinAssayTemplate"
-    } ],
-    "@id" : "bts:ProteinArrayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "ProteinArrayTemplate",
-    "rdfs:comment" : "Template for array- and immuno-based proteomics data.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:proteinExtractSource"
-    }, {
-      "@id" : "bts:antibodyID"
-    } ],
-    "sms:displayName" : "ProteinArrayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:GenomicsAssayTemplate"
-    } ],
-    "@id" : "bts:PdxGenomicsAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "PdxGenomicsAssayTemplate",
-    "rdfs:comment" : "Raw genomics data from patient-derived xenograft (PDX) experiment, with additional PDX-relevant metadata.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:nucleicAcidSource"
-    }, {
-      "@id" : "bts:specimenPreparationMethod"
-    }, {
-      "@id" : "bts:specimenType"
-    }, {
-      "@id" : "bts:runType"
-    }, {
-      "@id" : "bts:libraryStrand"
-    }, {
-      "@id" : "bts:libraryPrep"
-    }, {
-      "@id" : "bts:libraryPreparationMethod"
-    }, {
-      "@id" : "bts:readPair"
-    }, {
-      "@id" : "bts:readLength"
-    }, {
-      "@id" : "bts:readDepth"
-    }, {
-      "@id" : "bts:targetDepth"
-    }, {
-      "@id" : "bts:batchID"
-    }, {
-      "@id" : "bts:transplantationType"
-    }, {
-      "@id" : "bts:transplantationRecipientSpecies"
-    }, {
-      "@id" : "bts:transplantationRecipientTissue"
-    }, {
-      "@id" : "bts:experimentalCondition"
-    }, {
-      "@id" : "bts:experimentalTimepoint"
-    }, {
-      "@id" : "bts:timepointUnit"
-    } ],
-    "sms:displayName" : "PdxGenomicsAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:MaterialScienceAssayTemplate"
-    } ],
-    "@id" : "bts:LightScatteringAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "LightScatteringAssayTemplate",
-    "rdfs:comment" : "Template for dynamic or static light scattering data adapted from ISA-TAB-Nano specs.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:materialType"
-    }, {
-      "@id" : "bts:concentrationMaterial"
-    }, {
-      "@id" : "bts:concentrationMaterialUnit"
-    }, {
-      "@id" : "bts:concentrationNaCl"
-    }, {
-      "@id" : "bts:concentrationNaClUnit"
-    }, {
-      "@id" : "bts:pH"
-    } ],
-    "sms:displayName" : "LightScatteringAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BiologicalAssayDataTemplate"
-    } ],
-    "@id" : "bts:ProcessedAlignedReadsTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "ProcessedAlignedReadsTemplate",
-    "rdfs:comment" : "Template for describing aligned reads (e.g. BAM/CRAM files) from a sequencing assay. The QC meta are extracted from samtools stats when available and are the same metrics preferred by GDC. \n",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:genomicReference"
-    }, {
-      "@id" : "bts:genomicReferenceLink"
-    }, {
-      "@id" : "bts:averageInsertSize"
-    }, {
-      "@id" : "bts:averageReadLength"
-    }, {
-      "@id" : "bts:averageBaseQuality"
-    }, {
-      "@id" : "bts:pairsOnDifferentChr"
-    }, {
-      "@id" : "bts:readsDuplicatedPercent"
-    }, {
-      "@id" : "bts:readsMappedPercent"
-    }, {
-      "@id" : "bts:meanCoverage"
-    }, {
-      "@id" : "bts:proportionCoverage10x"
-    }, {
-      "@id" : "bts:proportionCoverage30x"
-    }, {
-      "@id" : "bts:readDepth"
-    }, {
-      "@id" : "bts:totalReads"
-    }, {
-      "@id" : "bts:workflow"
-    }, {
-      "@id" : "bts:workflowLink"
-    }, {
-      "@id" : "bts:auxiliaryAsset"
-    } ],
-    "sms:displayName" : "ProcessedAlignedReadsTemplate"
-  }, {
-    "rdfs:subClassOf" : [ ],
-    "@id" : "bts:HumanCohortTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "HumanCohortTemplate",
-    "rdfs:comment" : "Data of biosamples from human patients. Adapted from Table 2 of http://nrs.harvard.edu/urn-3:HUL.InstRepos:32725809. This template should be used when biosamples are from NF patients to provides a more valuable characterization and make additional gene-phenotype insights possible.\n",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:diagnosisAgeGroup"
-    }, {
-      "@id" : "bts:inheritance"
-    }, {
-      "@id" : "bts:mosaicism"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:germlineMutationIndicator"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:vitalStatus"
-    }, {
-      "@id" : "bts:WHOPerformanceStatus"
-    }, {
-      "@id" : "bts:painStatus"
-    }, {
-      "@id" : "bts:tumorTreatmentStatus"
-    }, {
-      "@id" : "bts:cafeaulaitMacules"
-    }, {
-      "@id" : "bts:skinFoldFreckling"
-    }, {
-      "@id" : "bts:IrisLischNodules"
-    }, {
-      "@id" : "bts:dermalNeurofibromas"
-    }, {
-      "@id" : "bts:subcutaneousNodularNeurofibromas"
-    }, {
-      "@id" : "bts:diffuseDermalNeurofibromas"
-    }, {
-      "@id" : "bts:spinalNeurofibromas"
-    }, {
-      "@id" : "bts:plexiformNeurofibromas"
-    }, {
-      "@id" : "bts:opticGlioma"
-    }, {
-      "@id" : "bts:heartDefect"
-    }, {
-      "@id" : "bts:vascularDisease"
-    }, {
-      "@id" : "bts:pubertyOnset"
-    }, {
-      "@id" : "bts:stature"
-    }, {
-      "@id" : "bts:peripheralNeuropathy"
-    }, {
-      "@id" : "bts:aqueductalStenosis"
-    }, {
-      "@id" : "bts:longBoneDysplasia"
-    }, {
-      "@id" : "bts:sphenoidDysplasia"
-    }, {
-      "@id" : "bts:scoliosis"
-    }, {
-      "@id" : "bts:intellectualDisability"
-    }, {
-      "@id" : "bts:learningDisability"
-    }, {
-      "@id" : "bts:attentionDeficitDisorder"
-    }, {
-      "@id" : "bts:pheochromocytoma"
-    }, {
-      "@id" : "bts:glomusTumor"
-    }, {
-      "@id" : "bts:MPNST"
-    }, {
-      "@id" : "bts:nonopticGlioma"
-    }, {
-      "@id" : "bts:GIST"
-    }, {
-      "@id" : "bts:leukemia"
-    }, {
-      "@id" : "bts:breastCancer"
-    }, {
-      "@id" : "bts:otherTumors"
-    }, {
-      "@id" : "bts:vestibularSchwannoma"
-    }, {
-      "@id" : "bts:meningioma"
-    }, {
-      "@id" : "bts:gliomaOrEpendymoma"
-    }, {
-      "@id" : "bts:spinalSchwannoma"
-    }, {
-      "@id" : "bts:dermalSchwannoma"
-    }, {
-      "@id" : "bts:nonvestibularCranialSchwannoma"
-    }, {
-      "@id" : "bts:lenticularopacity"
-    }, {
-      "@id" : "bts:nonvestibularSchwannomas"
-    }, {
-      "@id" : "bts:numberOfSchwannomas"
-    } ],
-    "sms:displayName" : "HumanCohortTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:Template"
-    } ],
-    "@id" : "bts:ProtocolTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "ProtocolTemplate",
-    "rdfs:comment" : "Template for describing a protocol document.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:title"
-    }, {
-      "@id" : "bts:author"
-    }, {
-      "@id" : "bts:citation"
-    }, {
-      "@id" : "bts:license"
-    }, {
-      "@id" : "bts:protocolAssay"
-    }, {
-      "@id" : "bts:protocolPurpose"
-    }, {
-      "@id" : "bts:sampleType"
-    }, {
-      "@id" : "bts:comments"
-    } ],
-    "sms:displayName" : "ProtocolTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BulkSequencingAssayTemplate"
-    } ],
-    "@id" : "bts:EpigenomiscAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "EpigenomiscAssayTemplate",
-    "rdfs:comment" : "Template for describing raw data from epigenetics sequencing assays such as bisulfite sequencing.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:nucleicAcidSource"
-    }, {
-      "@id" : "bts:specimenPreparationMethod"
-    }, {
-      "@id" : "bts:specimenType"
-    }, {
-      "@id" : "bts:runType"
-    }, {
-      "@id" : "bts:libraryStrand"
-    }, {
-      "@id" : "bts:libraryPrep"
-    }, {
-      "@id" : "bts:libraryPreparationMethod"
-    }, {
-      "@id" : "bts:readPair"
-    }, {
-      "@id" : "bts:readLength"
-    }, {
-      "@id" : "bts:readDepth"
-    }, {
-      "@id" : "bts:targetDepth"
-    }, {
-      "@id" : "bts:batchID"
-    }, {
-      "@id" : "bts:bisulfiteConversionKitID"
-    } ],
-    "sms:displayName" : "EpigenomiscAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BiologicalAssayDataTemplate"
-    } ],
-    "@id" : "bts:ProcessedExpressionTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "ProcessedExpressionTemplate",
-    "rdfs:comment" : "Template for quantified gene/protein expression data that are still represented as one file per sample.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:expressionUnit"
-    }, {
-      "@id" : "bts:workflow"
-    }, {
-      "@id" : "bts:workflowLink"
-    }, {
-      "@id" : "bts:auxiliaryAsset"
-    } ],
-    "sms:displayName" : "ProcessedExpressionTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:GeneticsAssayTemplate"
-    } ],
-    "@id" : "bts:GenomicsArrayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "GenomicsArrayTemplate",
-    "rdfs:comment" : "A template for describing raw data from array-based genomics/epigenomics, e.g. CEL files.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:nucleicAcidSource"
-    }, {
-      "@id" : "bts:specimenPreparationMethod"
-    }, {
-      "@id" : "bts:channel"
-    } ],
-    "sms:displayName" : "GenomicsArrayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:MassSpecAssayTemplate"
-    } ],
-    "@id" : "bts:ProteomicsAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "ProteomicsAssayTemplate",
-    "rdfs:comment" : "Alias to MassSpecAssayTemplate for backwards-compatibility.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:proteinExtractSource"
-    }, {
-      "@id" : "bts:dataCollectionMode"
-    } ],
-    "sms:displayName" : "ProteomicsAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BulkSequencingAssayTemplate"
-    } ],
-    "@id" : "bts:GenomicsAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "GenomicsAssayTemplate",
-    "rdfs:comment" : "Alias to BulkSequencingAssayTemplate, use for sequence data on a large scale when there is no template available that is more specific.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:nucleicAcidSource"
-    }, {
-      "@id" : "bts:specimenPreparationMethod"
-    }, {
-      "@id" : "bts:specimenType"
-    }, {
-      "@id" : "bts:runType"
-    }, {
-      "@id" : "bts:libraryStrand"
-    }, {
-      "@id" : "bts:libraryPrep"
-    }, {
-      "@id" : "bts:libraryPreparationMethod"
-    }, {
-      "@id" : "bts:readPair"
-    }, {
-      "@id" : "bts:readLength"
-    }, {
-      "@id" : "bts:readDepth"
-    }, {
-      "@id" : "bts:targetDepth"
-    }, {
-      "@id" : "bts:batchID"
-    } ],
-    "sms:displayName" : "GenomicsAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:Template"
-    } ],
-    "@id" : "bts:BiologicalAssayDataTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : null,
-    "rdfs:label" : "BiologicalAssayDataTemplate",
-    "rdfs:comment" : "A template defining basic metadata on deposited data artifacts (i.e. files) from experimental assays involving biosamples.  This is an abstract template; \"real\" template subclasses define additional properties appropriate for the type of data file (e.g. imaging vs sequencing).\n",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    } ],
-    "sms:displayName" : "BiologicalAssayDataTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BiologicalAssayDataTemplate"
-    } ],
-    "@id" : "bts:GeneticsAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "GeneticsAssayTemplate",
-    "rdfs:comment" : "Template for relatively raw data of RNA/DNA structure and expression.  This is an abstract template encapsulating data from low-throughput to high-throughput assays,  sequencing-based or non-sequencing based (e.g. microarrays, optical genome mapping).  In practice, data are more specifically typed and matched to one of the templates below.\n",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:nucleicAcidSource"
-    }, {
-      "@id" : "bts:specimenPreparationMethod"
-    } ],
-    "sms:displayName" : "GeneticsAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BulkSequencingAssayTemplate"
-    } ],
-    "@id" : "bts:WGSTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "WGSTemplate",
-    "rdfs:comment" : "Template for describing raw data from Whole Genome Sequencing (WGS)",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:nucleicAcidSource"
-    }, {
-      "@id" : "bts:specimenPreparationMethod"
-    }, {
-      "@id" : "bts:specimenType"
-    }, {
-      "@id" : "bts:runType"
-    }, {
-      "@id" : "bts:libraryStrand"
-    }, {
-      "@id" : "bts:libraryPrep"
-    }, {
-      "@id" : "bts:libraryPreparationMethod"
-    }, {
-      "@id" : "bts:readPair"
-    }, {
-      "@id" : "bts:readLength"
-    }, {
-      "@id" : "bts:readDepth"
-    }, {
-      "@id" : "bts:targetDepth"
-    }, {
-      "@id" : "bts:batchID"
-    } ],
-    "sms:displayName" : "WGSTemplate"
-  }, {
-    "rdfs:subClassOf" : [ ],
-    "@id" : "bts:ProcessedMergedDataTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "ProcessedMergedDataTemplate",
-    "rdfs:comment" : "Further processed data with multiple samples aggregated into one file. This may be also be known as level-4 data. Unlike level-2 and level-3 data, individual-level attributes such as age and sex are no longer surfaced on the data file directly.\n",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:workflow"
-    }, {
-      "@id" : "bts:workflowLink"
-    }, {
-      "@id" : "bts:auxiliaryAsset"
-    }, {
-      "@id" : "bts:assay"
-    } ],
-    "sms:displayName" : "ProcessedMergedDataTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:GeneticsAssayTemplate"
-    } ],
-    "@id" : "bts:ScSequencingAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "ScSequencingAssayTemplate",
-    "rdfs:comment" : "General template for raw RNA/DNA data, i.e. sequence data from a sequencing assay.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:nucleicAcidSource"
-    }, {
-      "@id" : "bts:specimenPreparationMethod"
-    }, {
-      "@id" : "bts:cellType"
-    }, {
-      "@id" : "bts:isCellLine"
-    }, {
-      "@id" : "bts:cellID"
-    }, {
-      "@id" : "bts:dissociationMethod"
-    }, {
-      "@id" : "bts:runType"
-    }, {
-      "@id" : "bts:libraryStrand"
-    }, {
-      "@id" : "bts:libraryPrep"
-    }, {
-      "@id" : "bts:libraryPreparationMethod"
-    }, {
-      "@id" : "bts:readPair"
-    }, {
-      "@id" : "bts:readLength"
-    }, {
-      "@id" : "bts:readDepth"
-    }, {
-      "@id" : "bts:targetDepth"
-    }, {
-      "@id" : "bts:batchID"
-    }, {
-      "@id" : "bts:auxiliaryAsset"
-    } ],
-    "sms:displayName" : "ScSequencingAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:PartialTemplate"
-    } ],
-    "@id" : "bts:UpdateMilestoneReport",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "UpdateMilestoneReport",
-    "rdfs:comment" : "Metadata template for updating milestone report values in NF studies -- currently a supported feature for NTAP and GFF.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:progressReportNumber"
-    } ],
-    "sms:displayName" : "UpdateMilestoneReport"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BiologicalAssayDataTemplate"
-    } ],
-    "@id" : "bts:PharmacokineticsAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "PharmacokineticsAssayTemplate",
-    "rdfs:comment" : "Generic template for describing data from a pharmacokinetics assay.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:compoundName"
-    }, {
-      "@id" : "bts:compoundDose"
-    }, {
-      "@id" : "bts:compoundDoseUnit"
-    }, {
-      "@id" : "bts:experimentalCondition"
-    }, {
-      "@id" : "bts:experimentalTimepoint"
-    }, {
-      "@id" : "bts:timepointUnit"
-    } ],
-    "sms:displayName" : "PharmacokineticsAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:GeneticsAssayTemplate"
-    } ],
-    "@id" : "bts:BulkSequencingAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "BulkSequencingAssayTemplate",
-    "rdfs:comment" : "General template for raw (level 1) RNA/DNA data, i.e. sequence data from a sequencing assay.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:nucleicAcidSource"
-    }, {
-      "@id" : "bts:specimenPreparationMethod"
-    }, {
-      "@id" : "bts:specimenType"
-    }, {
-      "@id" : "bts:runType"
-    }, {
-      "@id" : "bts:libraryStrand"
-    }, {
-      "@id" : "bts:libraryPrep"
-    }, {
-      "@id" : "bts:libraryPreparationMethod"
-    }, {
-      "@id" : "bts:readPair"
-    }, {
-      "@id" : "bts:readLength"
-    }, {
-      "@id" : "bts:readDepth"
-    }, {
-      "@id" : "bts:targetDepth"
-    }, {
-      "@id" : "bts:batchID"
-    } ],
-    "sms:displayName" : "BulkSequencingAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BiologicalAssayDataTemplate"
-    } ],
-    "@id" : "bts:ElectrophysiologyAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : null,
-    "rdfs:label" : "ElectrophysiologyAssayTemplate",
-    "rdfs:comment" : "Template for raw electrophysiology data (electrical recordings).",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:bodySite"
-    }, {
-      "@id" : "bts:cellType"
-    }, {
-      "@id" : "bts:recordingSource"
-    }, {
-      "@id" : "bts:experimentalTimepoint"
-    }, {
-      "@id" : "bts:timepointUnit"
-    }, {
-      "@id" : "bts:experimentalCondition"
-    }, {
-      "@id" : "bts:auxiliaryAsset"
-    } ],
-    "sms:displayName" : "ElectrophysiologyAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:ImagingAssayTemplate"
-    } ],
-    "@id" : "bts:MicroscopyAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "MicroscopyAssayTemplate",
-    "rdfs:comment" : "Template for data from a microscopy data.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:assayTarget"
-    }, {
-      "@id" : "bts:auxiliaryAsset"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:objective"
-    }, {
-      "@id" : "bts:nominalMagnification"
-    }, {
-      "@id" : "bts:lensAperture"
-    }, {
-      "@id" : "bts:workingDistance"
-    }, {
-      "@id" : "bts:workingDistanceUnit"
-    }, {
-      "@id" : "bts:immersion"
-    } ],
-    "sms:displayName" : "MicroscopyAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:MicroscopyAssayTemplate"
-    } ],
-    "@id" : "bts:ImmunoMicroscopyTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "ImmunoMicroscopyTemplate",
-    "rdfs:comment" : "Template for describing immunofluorescence or immunohistochemistry images.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:assayTarget"
-    }, {
-      "@id" : "bts:auxiliaryAsset"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:objective"
-    }, {
-      "@id" : "bts:nominalMagnification"
-    }, {
-      "@id" : "bts:lensAperture"
-    }, {
-      "@id" : "bts:workingDistance"
-    }, {
-      "@id" : "bts:workingDistanceUnit"
-    }, {
-      "@id" : "bts:immersion"
-    }, {
-      "@id" : "bts:antibodyID"
-    } ],
-    "sms:displayName" : "ImmunoMicroscopyTemplate"
-  }, {
-    "rdfs:subClassOf" : [ ],
-    "@id" : "bts:AnimalIndividualTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "AnimalIndividualTemplate",
-    "rdfs:comment" : "Template for non-human individual-level data.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:diagnosisAgeGroup"
-    }, {
-      "@id" : "bts:inheritance"
-    }, {
-      "@id" : "bts:mosaicism"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:germlineMutation"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:modelSystemName"
-    } ],
-    "sms:displayName" : "AnimalIndividualTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BiologicalAssayDataTemplate"
-    } ],
-    "@id" : "bts:PlateBasedReporterAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "PlateBasedReporterAssayTemplate",
-    "rdfs:comment" : "Generic template for describing data from a plate-based reporter assay.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:assayTarget"
-    }, {
-      "@id" : "bts:compoundName"
-    }, {
-      "@id" : "bts:compoundDose"
-    }, {
-      "@id" : "bts:compoundDoseUnit"
-    }, {
-      "@id" : "bts:experimentalCondition"
-    }, {
-      "@id" : "bts:experimentalTimepoint"
-    }, {
-      "@id" : "bts:timepointUnit"
-    }, {
-      "@id" : "bts:reporterGene"
-    }, {
-      "@id" : "bts:reporterSubstance"
-    } ],
-    "sms:displayName" : "PlateBasedReporterAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:ImagingAssayTemplate"
-    } ],
-    "@id" : "bts:MRIAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "MRIAssayTemplate",
-    "rdfs:comment" : "Template for describing MRI data.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:assayTarget"
-    }, {
-      "@id" : "bts:auxiliaryAsset"
-    }, {
-      "@id" : "bts:bodySite"
-    }, {
-      "@id" : "bts:MRISequence"
-    }, {
-      "@id" : "bts:experimentalCondition"
-    }, {
-      "@id" : "bts:experimentalTimepoint"
-    }, {
-      "@id" : "bts:timepointUnit"
-    } ],
-    "sms:displayName" : "MRIAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BulkSequencingAssayTemplate"
-    } ],
-    "@id" : "bts:WESTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "WESTemplate",
-    "rdfs:comment" : "Template for describing raw data from Whole Exome Sequencing (WES/WXS)",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:nucleicAcidSource"
-    }, {
-      "@id" : "bts:specimenPreparationMethod"
-    }, {
-      "@id" : "bts:specimenType"
-    }, {
-      "@id" : "bts:runType"
-    }, {
-      "@id" : "bts:libraryStrand"
-    }, {
-      "@id" : "bts:libraryPrep"
-    }, {
-      "@id" : "bts:libraryPreparationMethod"
-    }, {
-      "@id" : "bts:readPair"
-    }, {
-      "@id" : "bts:readLength"
-    }, {
-      "@id" : "bts:readDepth"
-    }, {
-      "@id" : "bts:targetDepth"
-    }, {
-      "@id" : "bts:batchID"
-    }, {
-      "@id" : "bts:targetCaptureKitID"
-    } ],
-    "sms:displayName" : "WESTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:Template"
-    } ],
-    "@id" : "bts:SourceCodeTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "SourceCodeTemplate",
-    "rdfs:comment" : "Template for describing scripts or software code.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:title"
-    }, {
-      "@id" : "bts:author"
-    }, {
-      "@id" : "bts:citation"
-    }, {
-      "@id" : "bts:license"
-    }, {
-      "@id" : "bts:programmingLanguage"
-    }, {
-      "@id" : "bts:runtimePlatform"
-    }, {
-      "@id" : "bts:documentation"
-    } ],
-    "sms:displayName" : "SourceCodeTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:EpigenomiscAssayTemplate"
-    } ],
-    "@id" : "bts:EpigeneticsAssayTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "EpigeneticsAssayTemplate",
-    "rdfs:comment" : "Alias for EpigenomiscAssayTemplate for backwards-compatibility.",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:parentSpecimenID"
-    }, {
-      "@id" : "bts:specimenID"
-    }, {
-      "@id" : "bts:aliquotID"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:nucleicAcidSource"
-    }, {
-      "@id" : "bts:specimenPreparationMethod"
-    }, {
-      "@id" : "bts:specimenType"
-    }, {
-      "@id" : "bts:runType"
-    }, {
-      "@id" : "bts:libraryStrand"
-    }, {
-      "@id" : "bts:libraryPrep"
-    }, {
-      "@id" : "bts:libraryPreparationMethod"
-    }, {
-      "@id" : "bts:readPair"
-    }, {
-      "@id" : "bts:readLength"
-    }, {
-      "@id" : "bts:readDepth"
-    }, {
-      "@id" : "bts:targetDepth"
-    }, {
-      "@id" : "bts:batchID"
-    }, {
-      "@id" : "bts:bisulfiteConversionKitID"
-    } ],
-    "sms:displayName" : "EpigeneticsAssayTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BiologicalAssayDataTemplate"
-    } ],
-    "@id" : "bts:ProcessedVariantCallsTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "ProcessedVariantCallsTemplate",
-    "rdfs:comment" : "Template for describing either simple germline/somatic variant calls output data (VCF/MAF) as well as structural variants (e.g. CNVs).",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:isFilteredReads"
-    }, {
-      "@id" : "bts:workflow"
-    }, {
-      "@id" : "bts:workflowLink"
-    }, {
-      "@id" : "bts:auxiliaryAsset"
-    } ],
-    "sms:displayName" : "ProcessedVariantCallsTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:Template"
-    } ],
-    "@id" : "bts:NonBiologicalAssayDataTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : null,
-    "rdfs:label" : "NonBiologicalAssayDataTemplate",
-    "rdfs:comment" : "A template for describing deposited data artifacts (i.e. files) from an experimental assay that main involves non-biological samples.   \n",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    } ],
-    "sms:displayName" : "NonBiologicalAssayDataTemplate"
-  }, {
-    "rdfs:subClassOf" : [ ],
-    "@id" : "bts:PortalDataset",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : null,
-    "rdfs:label" : "PortalDataset",
-    "rdfs:comment" : "A slightly more specialized dataset concept intended for the specific scope of the NF Portal; see https://nf.synapse.org/Explore/Datasets. \n",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ ],
-    "sms:displayName" : "PortalDataset"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:BiologicalAssayDataTemplate"
-    } ],
-    "@id" : "bts:FlowCytometryTemplate",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : "",
-    "rdfs:label" : "FlowCytometryTemplate",
-    "rdfs:comment" : "Template for flow cytometry assay",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:Component"
-    }, {
-      "@id" : "bts:Filename"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:dataType"
-    }, {
-      "@id" : "bts:dataSubtype"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:individualID"
-    }, {
-      "@id" : "bts:species"
-    }, {
-      "@id" : "bts:sex"
-    }, {
-      "@id" : "bts:age"
-    }, {
-      "@id" : "bts:ageUnit"
-    }, {
-      "@id" : "bts:diagnosis"
-    }, {
-      "@id" : "bts:nf1Genotype"
-    }, {
-      "@id" : "bts:nf2Genotype"
-    }, {
-      "@id" : "bts:tumorType"
-    }, {
-      "@id" : "bts:modelSystemName"
-    }, {
-      "@id" : "bts:organ"
-    }, {
-      "@id" : "bts:comments"
-    }, {
-      "@id" : "bts:platform"
-    }, {
-      "@id" : "bts:cellType"
-    }, {
-      "@id" : "bts:auxiliaryAsset"
-    } ],
-    "sms:displayName" : "FlowCytometryTemplate"
-  }, {
-    "rdfs:subClassOf" : [ {
-      "@id" : "bts:Template"
-    } ],
-    "@id" : "bts:WorkflowReport",
-    "schema:isPartOf" : {
-      "@id" : "http://schema.biothings.io/"
-    },
-    "sms:required" : "sms:false",
-    "sms:requiresComponent" : null,
-    "rdfs:label" : "WorkflowReport",
-    "rdfs:comment" : "Template used for miscellaneous workflow reports and accessory files",
-    "@type" : "rdfs:Class",
-    "sms:requiresDependency" : [ {
-      "@id" : "bts:resourceType"
-    }, {
-      "@id" : "bts:assay"
-    }, {
-      "@id" : "bts:fileFormat"
-    }, {
-      "@id" : "bts:relatedDataset"
-    }, {
-      "@id" : "bts:workflow"
-    }, {
-      "@id" : "bts:workflowLink"
-    } ],
-    "sms:displayName" : "WorkflowReport"
   }, {
     "@id" : "bts:autograft",
     "@type" : "rdfs:Class",

--- a/modules/Data/Data.yaml
+++ b/modules/Data/Data.yaml
@@ -109,7 +109,7 @@ enums:
         meaning: http://edamontology.org/data_0955
 
 
-  DataSubtype:
+  DataSubtypeEnum:
     permissible_values:
       normalized:
         description: A data set that is produced as the output of a normalization data transformation.

--- a/modules/props.yaml
+++ b/modules/props.yaml
@@ -283,7 +283,7 @@ slots:
     description: Further qualification of dataType, which may be used to indicate
       the state of processing of the data, aggregation of the data, or presence
       of metadata.
-    range: DataSubtype
+    range: DataSubtypeEnum
     required: true
   dataType:
     annotations:


### PR DESCRIPTION
@cconrad8 encountered this during mtDCA testing and I just realized this.

So before we upgraded to schematic 24.1.1 in https://github.com/nf-osi/nf-metadata-dictionary/pull/396, enums were capitalization-sensitive, so you could use `DataSubtype` as range and it would be fine because schematic still distinguished the _property_ `dataSubtype` from the _valid values_ `DataSubtype`. But now anything _valid values_ really needs to be DataSubtype**Enum** now.

Can see this by comparing templates generated in [PR 396](https://github.com/nf-osi/nf-metadata-dictionary/pull/396) with e.g. ones *_before_*, such as  [PR 393](https://github.com/nf-osi/nf-metadata-dictionary/pull/393).
 