### PR TITLE
make diagnosis required attribute

### DIFF
--- a/NF.jsonld
+++ b/NF.jsonld
@@ -1904,7 +1904,7 @@
     "schema:isPartOf" : {
       "@id" : "http://schema.biothings.io/"
     },
-    "sms:required" : "sms:false",
+    "sms:required" : "sms:true",
     "schema:rangeIncludes" : [ {
       "@id" : "bts:Neurofibromatosistype1"
     }, {
@@ -1923,6 +1923,8 @@
       "@id" : "bts:Schwannomatosis-NEC"
     }, {
       "@id" : "bts:SporadicSchwannoma"
+    }, {
+      "@id" : "bts:NotApplicable"
     } ],
     "rdfs:label" : "diagnosis",
     "rdfs:comment" : "Diagnosis for the individual given signs and symptoms. Use the most specific diagnosis term that applies.",

--- a/modules/Sample/Diagnosis.yaml
+++ b/modules/Sample/Diagnosis.yaml
@@ -26,6 +26,7 @@ enums:
           Most schwannomas originate from the eighth cranial nerve, whereas neurofibromas more commonly arise along the spinal nerve roots.
         notes:
         - Not in NCIT as of 2023-06-07
+      Not Applicable:
   
   AgeGroupEnum:
     permissible_values:

--- a/modules/props.yaml
+++ b/modules/props.yaml
@@ -342,7 +342,7 @@ slots:
   diagnosis:
     description: Diagnosis for the individual given signs and symptoms. Use the most specific diagnosis term that applies.
     range: DiagnosisEnum
-    required: false
+    required: true
   diagnosisAgeGroup:
     description: Age group of the individual at the time of diagnosis.
     range: AgeGroupEnum


### PR DESCRIPTION
I've noticed when helping with annotations that a lot of people skip this annotation, even when it is important (e.g. a cohort of people with and without NF). Since this is such a fundamental piece of clinical metadata for the NF Data Portal, I'm proposing that we make it required, and add a not applicable option for situations where diagnosis really is not relevant or applicable. 