### PR TITLE
Update for individualID

### DIFF
--- a/NF.jsonld
+++ b/NF.jsonld
@@ -4592,16 +4592,17 @@
     "sms:displayName" : "batchID",
     "sms:required" : "sms:false"
   }, {
-    "@id" : "bts:individualID",
-    "@type" : "rdfs:Class",
-    "rdfs:comment" : "A unique identifier (non-PII) that represents the individual from which the data came. This could be a patient or animal ID.",
-    "rdfs:label" : "individualID",
     "rdfs:subClassOf" : [ ],
+    "@id" : "bts:individualID",
     "schema:isPartOf" : {
       "@id" : "http://schema.biothings.io/"
     },
-    "sms:displayName" : "individualID",
-    "sms:required" : "sms:true"
+    "sms:required" : "sms:true",
+    "sms:validationRules" : [ "list like" ],
+    "rdfs:label" : "individualID",
+    "rdfs:comment" : "A unique identifier (non-PII) that represents the individual from which the data came. This could be a patient or animal ID.",
+    "@type" : "rdfs:Class",
+    "sms:displayName" : "individualID"
   }, {
     "rdfs:subClassOf" : [ ],
     "@id" : "bts:failedQC",

--- a/modules/props.yaml
+++ b/modules/props.yaml
@@ -496,6 +496,8 @@ slots:
     description: A unique identifier (non-PII) that represents the individual from
       which the data came. This could be a patient or animal ID.
     required: true
+    annotations:
+      validationRules: list like
   individualIdSource:
     description: Database or repository to which individual ID maps
     notes:


### PR DESCRIPTION
Related to [FDS-1968](https://sagebionetworks.jira.com/browse/FDS-1968).

So we should allow a list of IDs anyway, even aside from the above issue where I think schematic gets confused during submission when a field that's not supposed be a list ends up having commas (?). 