### PR TITLE
Update template selection

### DIFF
--- a/dca-template-config.json
+++ b/dca-template-config.json
@@ -20,10 +20,8 @@
       {"display_name": "Processed Expression Data", "schema_name": "ProcessedExpressionTemplate", "type": "file"},
       {"display_name": "FACS Template", "schema_name": "FlowCytometryTemplate", "type": "file"},
       {"display_name": "Light Scattering Assay", "schema_name": "LightScatteringAssayTemplate", "type": "file"},
-      {"display_name": "Protocol Resource", "schema_name": "ProtocolTemplate", "type": "file"},
-      {"display_name": "Human Individuals", "schema_name": "HumanCohortTemplate", "type": "record"},
-      {"display_name": "Animal Individuals", "schema_name": "AnimalIndividualTemplate", "type": "record"},
-      {"display_name": "Biopecimens", "schema_name": "BiospecimenTemplate", "type": "record"}
+      {"display_name": "Protocols", "schema_name": "ProtocolTemplate", "type": "file"},
+      {"display_name": "Human Individuals (Extended Biobanking Data)", "schema_name": "HumanCohortTemplate", "type": "record"}
     ],
   "main_fileview" : "syn16858331",
   "community" : "NF",


### PR DESCRIPTION
Improve naming for experimental, not often used templates, and remove ones like "Animal Individuals" where we don't plan to pilot or test currently.