### PR TITLE
Update devcontainer

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
-pip3 install schematicpy==24.1.1
+pip3 install schematicpy==24.5.1 ipython==8.18.1
 sudo bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
 git clone --depth 1 https://github.com/anngvu/retold.git
+

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  SCHEMATIC_VERSION: 24.5.1
+  SCHEMATIC_VERSION: 24.5.1 # please update .devcontainer as well until this can be set globally somewhere...
   
 jobs:
   build:
@@ -51,6 +51,8 @@ jobs:
       
       - name: Setup schematic and do another convert pass
         id: schematic-convert
+        # Note: remove ipython==8.18.1 workaround for future release mentioned in 
+        # https://sagebionetworks.slack.com/archives/C050YD75QRL/p1715357806542429?thread_ts=1715357453.519969&cid=C050YD75QRL
         run: |
           pip install schematicpy==${{ env.SCHEMATIC_VERSION }}  ipython==8.18.1
           pip show schematicpy


### PR DESCRIPTION
OK, I see what's going on. So there was a `typing_extensions` issue that cropped up around April, and a workaround/fix was put into https://github.com/nf-osi/nf-metadata-dictionary/pull/421 but I neglected the .devcontainer 😞 .

Before patch:
![image](https://github.com/nf-osi/nf-metadata-dictionary/assets/32753274/085e5e23-df14-4578-9259-0bb7275fa4bc)


After patch:
![image](https://github.com/nf-osi/nf-metadata-dictionary/assets/32753274/9f4461dc-ce3e-464c-babe-22f3fc66a88c)

