### PR TITLE
Update workflow installs with schematic 24.7.1

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pip3 install schematicpy==24.5.1 ipython==8.18.1
+pip3 install schematicpy==24.7.1
 sudo bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
 git clone --depth 1 https://github.com/anngvu/retold.git
 

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  SCHEMATIC_VERSION: 24.5.1 # please update .devcontainer as well until this can be set globally somewhere...
+  SCHEMATIC_VERSION: 24.7.1 # please update .devcontainer as well until this can be set globally somewhere...
   
 jobs:
   build:
@@ -107,7 +107,7 @@ jobs:
       - name: Setup schematic
         id: setup-schematic
         run: |
-          pip install schematicpy==${{ env.SCHEMATIC_VERSION }}  ipython==8.18.1
+          pip install schematicpy==${{ env.SCHEMATIC_VERSION }}
           pip show schematicpy
 
       - name: Test generate


### PR DESCRIPTION
https://github.com/Sage-Bionetworks/schematic/releases/tag/v24.7.1

Looking at release notes, workaround with `ipython` was removed successfully.

**Update:**

Just FYI, there are two submission failures that are a little confusing and might have to do with the test setup that I need to fix (concurrency issues with other tests running given multiple PRs at the same time ?) / doesn't seem to be schematic issue, since the other submissions pass. Overall, this update should be OK.
```
✓ Set up NF.jsonld for test
Using '../validate' as the scope containing all possible manifests for submission tests.
Using '../validate/logs' to filter for valid/qualifying manifests.
This manifest qualifies for and will undergo test submission: ../validate/GenomicsAssayTemplate_0.csv
Creating mock dataset folder...
Creating mock entities...

SynapseHTTPError: 403 Client Error: 
Lack of READ permission on the parent entity.


SynapseHTTPError: 403 Client Error: 
Lack of READ permission on the parent entity.
```