### PR TITLE
Portal dataset access

### DIFF
--- a/NF.jsonld
+++ b/NF.jsonld
@@ -8918,6 +8918,9 @@
                 },
                 {
                     "@id": "bts:ControlledAccess"
+                },
+                {
+                    "@id": "bts:PrivateAccess"
                 }
             ],
             "sms:displayName": "accessType",
@@ -8972,6 +8975,23 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Controlled Access",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:PrivateAccess",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "PrivateAccess",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:AccessType"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Private Access",
             "sms:required": "sms:false",
             "sms:validationRules": []
         },

--- a/modules/DCC/Portal.yaml
+++ b/modules/DCC/Portal.yaml
@@ -3,14 +3,17 @@ enums:
     title: Access types
     permissible_values:
       Public Access:
-        description: Access without any additional steps/requirements, without even needing a Synapse account.
-      Open Access:
         description: Access without any additional steps/requirements as long as you are logged in to Synapse.
+      Open Access:
+        description: Access without any additional steps/requirements without even needing a Synapse account.
       Controlled Access:
         description: > 
           Access is restricted and only available after fulfilling specific requirements, such as submitting a research statement or getting approval directly from the data owner through Synapse.
           Note that for datasets, if any component file is under controlled access, the entire dataset is considered to be under controlled access.
+      Private Access:
+        description: This is not accessible outside the project admins and study team. Contact the PI to request access.
   
+
   DataStatusEnum:
     title: Data Status
     permissible_values:

--- a/modules/DCC/Portal.yaml
+++ b/modules/DCC/Portal.yaml
@@ -10,13 +10,13 @@ enums:
       Public Access:
         description: Access without any additional steps/requirements as long as you are logged in to Synapse.
       Open Access:
-        description: Access without any additional steps/requirements without even needing a Synapse account.
+        description: Access without any additional steps/requirements without even needing to be logged in to Synapse account.
       Controlled Access:
         description: > 
           Access is restricted and only available after fulfilling specific requirements, such as submitting a research statement or getting approval directly from the data owner through Synapse.
           Note that for datasets, if any component file is under controlled access, the entire dataset is considered to be under controlled access.
       Private Access:
-        description: Not accessible outside the project admins and study team -- check whether you are on an access team. Contact the PI to request access.
+        description: Not accessible outside the project admins and study team -- check whether you are on an access team or contact the PI/admin of access team to request access.
   
 
   DataStatusEnum:

--- a/modules/DCC/Portal.yaml
+++ b/modules/DCC/Portal.yaml
@@ -2,8 +2,8 @@ enums:
   AccessTypeEnum:
     title: Access type
     notes:
-    - Historically has been used with `accessTeam` espcially if "PRIVATE".
-    - All files have to qualify to be labeled as such, e.g. a single Controlled Access file will make the dataset Controlled access.
+    - Historically has been used with `accessTeam` especially if "PRIVATE".
+    - All files have to qualify to be labeled as such, e.g. a single Controlled Access file will make the dataset Controlled Access.
     - This is not personalized to the user. They will have to evaluate it from their perspective, we are not dynamically rendering this.
     - See also https://github.com/PAIR-code/datacardsplaybook/blob/main/templates/DataCardsExtendedTemplate.md#access-type
     permissible_values:

--- a/modules/DCC/Portal.yaml
+++ b/modules/DCC/Portal.yaml
@@ -1,6 +1,11 @@
 enums:
   AccessTypeEnum:
-    title: Access types
+    title: Access type
+    notes:
+    - Historically has been used with `accessTeam` espcially if "PRIVATE".
+    - All files have to qualify to be labeled as such, e.g. a single Controlled Access file will make the dataset Controlled access.
+    - This is not personalized to the user. They will have to evaluate it from their perspective, we are not dynamically rendering this.
+    - See also https://github.com/PAIR-code/datacardsplaybook/blob/main/templates/DataCardsExtendedTemplate.md#access-type
     permissible_values:
       Public Access:
         description: Access without any additional steps/requirements as long as you are logged in to Synapse.
@@ -11,7 +16,7 @@ enums:
           Access is restricted and only available after fulfilling specific requirements, such as submitting a research statement or getting approval directly from the data owner through Synapse.
           Note that for datasets, if any component file is under controlled access, the entire dataset is considered to be under controlled access.
       Private Access:
-        description: This is not accessible outside the project admins and study team. Contact the PI to request access.
+        description: Not accessible outside the project admins and study team -- check whether you are on an access team. Contact the PI to request access.
   
 
   DataStatusEnum:

--- a/registered-json-schemas/PortalDataset.json
+++ b/registered-json-schemas/PortalDataset.json
@@ -8,7 +8,8 @@
         "enum": [
           "Public Access",
           "Open Access",
-          "Controlled Access"
+          "Controlled Access",
+          "Private Access"
         ],
         "title": "accessType",
         "type": "string"


### PR DESCRIPTION
We don't really use `accessType` _on datasets_ yet, but this should help with finalizing semantics so that correct code** can be implemented. This update also conveys that datasets don't have to be released (with or without restrictions) to be in the portal listing.

**to derive status from files at the time of dataset new-versioning.

Also see explanation here for the revision: https://sagebionetworks.slack.com/archives/C0AFCTGEQ/p1721857413285619?thread_ts=1721840221.098519&cid=C0AFCTGEQ

These definitions definitely need to go into the Confluence docs somewhere...