### PR TITLE
Add LinkML make demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ tests/submit/NF.jsonld
 tests/test-suite-report.md
 tests/**/logs
 publish/**
+nfosi.xlsx
 
 **/schematic
 *.schema.json

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,14 @@ convert:
 
 # Example generation of manifests as Excel using LinkML -- each manifest is a sheet with dropdowns where appropriate
 # We DON'T normally use these products, but this step is useful to provide as example for some
+# There seems to be a bug where enum_range seems to be handled correctly, but this is relevant for only small set of attributes
+# where we can migrate to using defined enums instead of inlined enums
 ManifestLinkMLDemo:
 	yq eval-all '. as $$item ireduce ({}; . * $$item )' header.yaml modules/props.yaml modules/**/*.yaml > merged.yaml
 	yq 'del(.. | select(has("annotations")).annotations)' merged.yaml > merged_no_extra_meta.yaml
 	yq 'del(.. | select(has("enum_range")).enum_range)' merged_no_extra_meta.yaml > merged_final.yaml
 	gen-excel merged_final.yaml
-	rm -rf merged_final.yaml
+	rm -rf merged**.yaml
 	
 
 # Recompile certain json schemas with LinkML with selective import of props, enums, and template 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ ManifestLinkMLDemo:
 	yq 'del(.. | select(has("annotations")).annotations)' merged.yaml > merged_no_extra_meta.yaml
 	yq 'del(.. | select(has("enum_range")).enum_range)' merged_no_extra_meta.yaml > merged_final.yaml
 	gen-excel merged_final.yaml
+	rm -rf merged_final.yaml
 	
 
 # Recompile certain json schemas with LinkML with selective import of props, enums, and template 


### PR DESCRIPTION
Hey @nf-osi/dcc-team (if you're interested) and @andrewelamb, for awareness this is how you would use LinkML to generate Excel manifests. I am using the latest version of LinkML. 

We don't use the Excel manifest because we use schematic Googlesheets, but if you ever want to do the comparison, here it is:
- Clone this branch.
- run `make ManifestLinkMLDemo`
- Each manifest is a sheet in the default output `nfosi.xlsx` file (attached: [nfosi.xlsx](https://github.com/user-attachments/files/18497848/nfosi.xlsx))

Here are some findings (not exhaustive):
- Apparently there _is_ an important limitation for valid value dropdowns -- lots of warnings for "total length > 255 characters. Dropdowns may not work properly in /home/avu/sage/nf/nf-metadata-dictionary/nfosi.xlsx"
- Not sure if there's an easy way to get one Excel file per manifest instead of everything in one giant Excel file, as it doesn't seem to be an option to select only the template I want to generate in the `gen-excel` command.


