### PR TITLE
Close #561

### DIFF
--- a/NF.jsonld
+++ b/NF.jsonld
@@ -688,6 +688,23 @@
             "sms:validationRules": []
         },
         {
+            "@id": "bts:DataCatalogEnum",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "DataCatalogEnum",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:Thing"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "DataCatalogEnum",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
             "@id": "bts:Percentiles-2SD",
             "@type": "rdfs:Class",
             "rdfs:comment": "Enumerations corresponding to 3 bins using 2 standard deviations as a cutoff.",
@@ -1228,6 +1245,23 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "DataStatusEnum",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:DataSeriesEnum",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "DataSeriesEnum",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:Thing"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "DataSeriesEnum",
             "sms:required": "sms:false",
             "sms:validationRules": []
         },
@@ -40378,6 +40412,23 @@
             "sms:validationRules": []
         },
         {
+            "@id": "bts:Https://www.synapse.org/DataCatalog:0",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Https://www.synapse.org/DataCatalog:0",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:Thing"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "//www.synapse.org/DataCatalog",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
             "@id": "bts:GFF",
             "@type": "rdfs:Class",
             "rdfs:comment": "TBD",
@@ -40442,6 +40493,23 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "brain development",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:NF-OSIProcessedData",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "NF-OSIProcessedData",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:Thing"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "NF-OSI Processed Data",
             "sms:required": "sms:false",
             "sms:validationRules": []
         },

--- a/modules/DCC/Portal.yaml
+++ b/modules/DCC/Portal.yaml
@@ -63,6 +63,10 @@ enums:
   DataCatalogEnum:
     permissible_values:
       'https://www.synapse.org/DataCatalog:0':
+
+  DataSeriesEnum:
+    permissible_values:
+      NF-OSI Processed Data:
   
   FundingAgencyEnum:
     permissible_values:

--- a/modules/DCC/Portal.yaml
+++ b/modules/DCC/Portal.yaml
@@ -60,6 +60,10 @@ enums:
       Schwannomatosis-NEC:
       Multiple:
   
+  DataCatalogEnum:
+    permissible_values:
+      'https://www.synapse.org/DataCatalog:0':
+  
   FundingAgencyEnum:
     permissible_values:
       NTAP:

--- a/modules/Template/PortalDataset.yaml
+++ b/modules/Template/PortalDataset.yaml
@@ -81,8 +81,9 @@ classes:
         multivalued: true
         required: true
       series:
-        title: Catalog Series
+        title: Data Series
         range: string
+        description: Datasets may belong to a curated series. This should be assigned by staff only.
         required: false
       visualizeDataOn:
         title: Visualize Data On
@@ -99,6 +100,6 @@ classes:
         required: false
       includedInDataCatalog:
         title: Included In Data Catalog
-        range: string
+        range: DataCatalogEnum
         required: false
 

--- a/modules/Template/PortalDataset.yaml
+++ b/modules/Template/PortalDataset.yaml
@@ -82,24 +82,28 @@ classes:
         required: true
       series:
         title: Data Series
-        range: string
+        range: DataSeriesEnum
         description: Datasets may belong to a curated series. This should be assigned by staff only.
         required: false
       visualizeDataOn:
         title: Visualize Data On
+        description: Link(s) to where data may be visualized in a separate application.
         range: string
         multivalued: true
         required: false
       yearProcessed:
         title: Year Processed
+        description: Year data were processed. Typically only used for processed data type and when data series is "NF-OSI Processed Data".
         range: integer
         required: false
       yearPublished:
         title: Year Published
+        description: Year data were published/available on Synapse.
         range: integer
         required: false
       includedInDataCatalog:
         title: Included In Data Catalog
+        description: Link(s) to known data catalog(s) the dataset is included in.
         range: DataCatalogEnum
         required: false
 

--- a/registered-json-schemas/PortalDataset.json
+++ b/registered-json-schemas/PortalDataset.json
@@ -307,11 +307,12 @@
       "type": "array"
     },
     "includedInDataCatalog": {
+      "description": "Link(s) to known data catalog(s) the dataset is included in.",
       "title": "Included In Data Catalog",
-      "type": "string",
       "enum": [
-          "https://www.synapse.org/DataCatalog:0"
-      ]
+        "https://www.synapse.org/DataCatalog:0"
+      ],
+      "type": "string"
     },
     "license": {
       "title": "License",
@@ -364,7 +365,11 @@
       "type": "array"
     },
     "series": {
-      "title": "Catalog Series",
+      "description": "Datasets may belong to a curated series. This should be assigned by staff only.",
+      "title": "Data Series",
+      "enum": [
+        "NF-OSI Processed Data"
+      ],
       "type": "string"
     },
     "species": {
@@ -398,6 +403,7 @@
       "type": "string"
     },
     "visualizeDataOn": {
+      "description": "Link(s) to where data may be visualized in a separate application.",
       "items": {
         "type": "string"
       },
@@ -405,10 +411,12 @@
       "type": "array"
     },
     "yearProcessed": {
+      "description": "Year data were processed. Typically only used for processed data type and when data series is \"NF-OSI Processed Data\".",
       "title": "Year Processed",
       "type": "integer"
     },
     "yearPublished": {
+      "description": "Year data were published/available on Synapse.",
       "title": "Year Published",
       "type": "integer"
     }

--- a/registered-json-schemas/Superdataset.json
+++ b/registered-json-schemas/Superdataset.json
@@ -307,7 +307,11 @@
       "type": "array"
     },
     "includedInDataCatalog": {
+      "description": "Link(s) to known data catalog(s) the dataset is included in.",
       "title": "Included In Data Catalog",
+      "enum": [
+        "https://www.synapse.org/DataCatalog:0"
+      ],
       "type": "string"
     },
     "license": {
@@ -361,7 +365,11 @@
       "type": "array"
     },
     "series": {
-      "title": "Catalog Series",
+      "description": "Datasets may belong to a curated series. This should be assigned by staff only.",
+      "title": "Data Series",
+      "enum": [
+        "NF-OSI Processed Data"
+      ],
       "type": "string"
     },
     "species": {
@@ -395,6 +403,7 @@
       "type": "string"
     },
     "visualizeDataOn": {
+      "description": "Link(s) to where data may be visualized in a separate application.",
       "items": {
         "type": "string"
       },
@@ -402,10 +411,12 @@
       "type": "array"
     },
     "yearProcessed": {
+      "description": "Year data were processed. Typically only used for processed data type and when data series is \"NF-OSI Processed Data\".",
       "title": "Year Processed",
       "type": "integer"
     },
     "yearPublished": {
+      "description": "Year data were published/available on Synapse.",
       "title": "Year Published",
       "type": "integer"
     }


### PR DESCRIPTION
Close #561. Fix enums, e.g. for `series`, and add better descriptions to reduce misunderstanding when curating with Syndi.