### PR TITLE
Resolve 471

### DIFF
--- a/NF.jsonld
+++ b/NF.jsonld
@@ -12129,6 +12129,9 @@
                     "@id": "bts:Title"
                 },
                 {
+                    "@id": "bts:Description"
+                },
+                {
                     "@id": "bts:AlternateName"
                 },
                 {
@@ -12138,16 +12141,7 @@
                     "@id": "bts:Contributor"
                 },
                 {
-                    "@id": "bts:Description"
-                },
-                {
-                    "@id": "bts:AccessType"
-                },
-                {
-                    "@id": "bts:License"
-                },
-                {
-                    "@id": "bts:CountryOfOrigin"
+                    "@id": "bts:StudyId"
                 },
                 {
                     "@id": "bts:MeasurementTechnique"
@@ -12163,9 +12157,6 @@
                 },
                 {
                     "@id": "bts:Species"
-                },
-                {
-                    "@id": "bts:StudyId"
                 },
                 {
                     "@id": "bts:Manifestation"
@@ -12198,12 +12189,41 @@
                     "@id": "bts:IncludedInDataCatalog"
                 },
                 {
+                    "@id": "bts:Citation"
+                },
+                {
+                    "@id": "bts:CountryOfOrigin"
+                },
+                {
+                    "@id": "bts:AccessType"
+                },
+                {
+                    "@id": "bts:License"
+                },
+                {
                     "@id": "bts:DataUseModifiers"
                 },
                 {
                     "@id": "bts:ConditionsOfAccess"
                 }
             ],
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Description",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "Text describing a resource.",
+            "rdfs:label": "Description",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:Thing"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "description",
+            "sms:required": "sms:false",
             "sms:validationRules": []
         },
         {
@@ -12254,71 +12274,6 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "contributor",
-            "sms:required": "sms:false",
-            "sms:validationRules": []
-        },
-        {
-            "@id": "bts:Description",
-            "@type": "rdfs:Class",
-            "rdfs:comment": "Text describing a resource.",
-            "rdfs:label": "Description",
-            "rdfs:subClassOf": [
-                {
-                    "@id": "bts:Thing"
-                }
-            ],
-            "schema:isPartOf": {
-                "@id": "http://schema.biothings.io"
-            },
-            "sms:displayName": "description",
-            "sms:required": "sms:false",
-            "sms:validationRules": []
-        },
-        {
-            "@id": "bts:AccessType",
-            "@type": "rdfs:Class",
-            "rdfs:comment": "Indicates access type / possible procedures needed for access to the resource.",
-            "rdfs:label": "AccessType",
-            "rdfs:subClassOf": [
-                {
-                    "@id": "bts:Thing"
-                }
-            ],
-            "schema:isPartOf": {
-                "@id": "http://schema.biothings.io"
-            },
-            "schema:rangeIncludes": [
-                {
-                    "@id": "bts:PublicAccess"
-                },
-                {
-                    "@id": "bts:OpenAccess"
-                },
-                {
-                    "@id": "bts:ControlledAccess"
-                },
-                {
-                    "@id": "bts:PrivateAccess"
-                }
-            ],
-            "sms:displayName": "accessType",
-            "sms:required": "sms:true",
-            "sms:validationRules": []
-        },
-        {
-            "@id": "bts:CountryOfOrigin",
-            "@type": "rdfs:Class",
-            "rdfs:comment": "TBD",
-            "rdfs:label": "CountryOfOrigin",
-            "rdfs:subClassOf": [
-                {
-                    "@id": "bts:Thing"
-                }
-            ],
-            "schema:isPartOf": {
-                "@id": "http://schema.biothings.io"
-            },
-            "sms:displayName": "countryOfOrigin",
             "sms:required": "sms:false",
             "sms:validationRules": []
         },
@@ -12509,6 +12464,54 @@
             },
             "sms:displayName": "includedInDataCatalog",
             "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:CountryOfOrigin",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CountryOfOrigin",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:Thing"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "countryOfOrigin",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:AccessType",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "Indicates access type / possible procedures needed for access to the resource.",
+            "rdfs:label": "AccessType",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:Thing"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": [
+                {
+                    "@id": "bts:PublicAccess"
+                },
+                {
+                    "@id": "bts:OpenAccess"
+                },
+                {
+                    "@id": "bts:ControlledAccess"
+                },
+                {
+                    "@id": "bts:PrivateAccess"
+                }
+            ],
+            "sms:displayName": "accessType",
+            "sms:required": "sms:true",
             "sms:validationRules": []
         },
         {

--- a/NF.jsonld
+++ b/NF.jsonld
@@ -12177,6 +12177,12 @@
                     "@id": "bts:Funder"
                 },
                 {
+                    "@id": "bts:IndividualCount"
+                },
+                {
+                    "@id": "bts:SpecimenCount"
+                },
+                {
                     "@id": "bts:Series"
                 },
                 {
@@ -12381,6 +12387,40 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "funder",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:IndividualCount",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "IndividualCount",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:Thing"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "individualCount",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:SpecimenCount",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "SpecimenCount",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:Thing"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "specimenCount",
             "sms:required": "sms:false",
             "sms:validationRules": []
         },

--- a/NF.ttl
+++ b/NF.ttl
@@ -12,22 +12,22 @@
 
 <https://w3id.org/synapse/nfosi/vocab/nfosi> a linkml:SchemaDefinition ;
     dcterms:license "https://creativecommons.org/publicdomain/zero/1.0/" ;
-    sh:declare [ sh:namespace skos: ;
-            sh:prefix "skos" ],
-        [ sh:namespace linkml: ;
-            sh:prefix "linkml" ],
-        [ sh:namespace <https://w3id.org/synapse/nfosi/vocab/> ;
+    sh:declare [ sh:namespace <https://w3id.org/synapse/nfosi/vocab/> ;
             sh:prefix "nf" ],
-        [ sh:namespace schema1: ;
-            sh:prefix "schema" ],
-        [ sh:namespace <https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld> ;
-            sh:prefix "htan" ],
-        [ sh:namespace <https://w3id.org/linkml/examples/personinfo/> ;
-            sh:prefix "personinfo" ],
         [ sh:namespace prov: ;
             sh:prefix "prov" ],
         [ sh:namespace rdfs: ;
-            sh:prefix "rdfs" ] ;
+            sh:prefix "rdfs" ],
+        [ sh:namespace linkml: ;
+            sh:prefix "linkml" ],
+        [ sh:namespace <https://w3id.org/linkml/examples/personinfo/> ;
+            sh:prefix "personinfo" ],
+        [ sh:namespace <https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld> ;
+            sh:prefix "htan" ],
+        [ sh:namespace schema1: ;
+            sh:prefix "schema" ],
+        [ sh:namespace skos: ;
+            sh:prefix "skos" ] ;
     linkml:classes <https://w3id.org/synapse/nfosi/vocab/AnimalIndividualTemplate>,
         <https://w3id.org/synapse/nfosi/vocab/BiologicalAssayDataTemplate>,
         <https://w3id.org/synapse/nfosi/vocab/BiospecimenTemplate>,
@@ -169,7 +169,7 @@
         <https://w3id.org/synapse/nfosi/vocab/WHOPerformanceStatusScores>,
         <https://w3id.org/synapse/nfosi/vocab/WorkflowEnum>,
         <https://w3id.org/synapse/nfosi/vocab/WorkingDistanceUnitEnum> ;
-    linkml:generation_date "2025-03-07T22:48:05"^^xsd:dateTime ;
+    linkml:generation_date "2025-03-19T16:20:02"^^xsd:dateTime ;
     linkml:id <https://w3id.org/nfosi/> ;
     linkml:imports linkml:types ;
     linkml:metamodel_version "1.7.0" ;
@@ -341,12 +341,14 @@
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__diseaseFocus>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__funder>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__includedInDataCatalog>,
+        <https://w3id.org/synapse/nfosi/vocab/portalDataset__individualCount>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__keywords>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__license>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__manifestation>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__measurementTechnique>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__series>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__species>,
+        <https://w3id.org/synapse/nfosi/vocab/portalDataset__specimenCount>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__studyId>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__subject>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__title>,
@@ -461,8 +463,8 @@
         <https://w3id.org/synapse/nfosi/vocab/yearProcessed>,
         <https://w3id.org/synapse/nfosi/vocab/yearPublished> ;
     linkml:source_file "NF.yaml" ;
-    linkml:source_file_date "2025-03-07T22:48:03"^^xsd:dateTime ;
-    linkml:source_file_size 297911 ;
+    linkml:source_file_date "2025-03-19T16:20:01"^^xsd:dateTime ;
+    linkml:source_file_size 298524 ;
     linkml:types <https://w3id.org/synapse/nfosi/vocab/boolean>,
         <https://w3id.org/synapse/nfosi/vocab/curie>,
         <https://w3id.org/synapse/nfosi/vocab/date>,
@@ -4051,7 +4053,7 @@
 
 <https://w3id.org/synapse/nfosi/vocab/dataUseModifiers> a linkml:SlotDefinition ;
     dcterms:title "Data Use Modifiers" ;
-    skos:definition "List of data use ontology (DUO) terms that are true for dataset, which describes the allowable scope and terms for data use. Omit property if not applicable/unknown." ;
+    skos:definition "List of data use ontology (DUO) terms that are true for dataset, which describes the allowable scope and terms for data use. Most datasets allow \"General Research Use\" unless otherwise specified." ;
     linkml:multivalued true ;
     linkml:range <https://w3id.org/synapse/nfosi/vocab/DuoEnum> .
 
@@ -4097,6 +4099,11 @@
     skos:definition "Link(s) to known data catalog(s) the dataset is included in." ;
     linkml:range <https://w3id.org/synapse/nfosi/vocab/DataCatalogEnum> .
 
+<https://w3id.org/synapse/nfosi/vocab/individualCount> a linkml:SlotDefinition ;
+    dcterms:title "Individual Count" ;
+    skos:definition "Number of unique individuals included in the dataset (whether as individual-level or as aggregate data). Omit if not applicable/unknown." ;
+    linkml:range <https://w3id.org/synapse/nfosi/vocab/integer> .
+
 <https://w3id.org/synapse/nfosi/vocab/institutions> a linkml:SlotDefinition ;
     linkml:multivalued true ;
     linkml:range <https://w3id.org/synapse/nfosi/vocab/Institution> ;
@@ -4115,7 +4122,7 @@
 
 <https://w3id.org/synapse/nfosi/vocab/measurementTechnique> a linkml:SlotDefinition ;
     dcterms:title "Measurement Technique" ;
-    skos:definition "Assay used to generate original data. Omit if not applicable (e.g. for curated dataset such as a list compounds from a database or text extracted from Wikipedia)." ;
+    skos:definition "What's used to generate original data, typically referring to the assay. Omit if not applicable (e.g. for curated dataset such as a list compounds from a database or text extracted from Wikipedia)." ;
     linkml:range <https://w3id.org/synapse/nfosi/vocab/AssayEnum> .
 
 <https://w3id.org/synapse/nfosi/vocab/metadata> skos:definition "A file of clinical, technical, or other parameters that describe a dataset.",
@@ -4163,7 +4170,7 @@
 
 <https://w3id.org/synapse/nfosi/vocab/portalDataset__contributor> a linkml:SlotDefinition ;
     dcterms:title "Contributor(s)" ;
-    skos:definition "Organization(s) or person(s) that contributed to the dataset." ;
+    skos:definition "Properly formatted name of organization(s) or person(s) that contributed to the dataset." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     skos:prefLabel "contributor" ;
     linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/PortalDataset> ;
@@ -4185,7 +4192,7 @@
 
 <https://w3id.org/synapse/nfosi/vocab/portalDataset__creator> a linkml:SlotDefinition ;
     dcterms:title "Creator" ;
-    skos:definition "Organization or person that is creator of the dataset. Default is the PI of the project and/or the user who created all files in the dataset." ;
+    skos:definition "Properly formatted name of the organization or person that is creator of the dataset (e.g. \"NF-OSI\" or \"Robert Allaway\"), not an id. Default is the project PI and/or the user who created all files/records." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     skos:prefLabel "creator" ;
     linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/PortalDataset> ;
@@ -4196,7 +4203,7 @@
 
 <https://w3id.org/synapse/nfosi/vocab/portalDataset__dataType> a linkml:SlotDefinition ;
     dcterms:title "Data Type" ;
-    skos:definition "Reflects the data types of files within the dataset." ;
+    skos:definition "Reflects the data types within the dataset." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     skos:prefLabel "dataType" ;
     linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/PortalDataset> ;
@@ -4208,7 +4215,7 @@
 
 <https://w3id.org/synapse/nfosi/vocab/portalDataset__dataUseModifiers> a linkml:SlotDefinition ;
     dcterms:title "Data Use Modifiers" ;
-    skos:definition "List of data use ontology (DUO) terms that are true for dataset, which describes the allowable scope and terms for data use. Omit property if not applicable/unknown." ;
+    skos:definition "List of data use ontology (DUO) terms that are true for dataset, which describes the allowable scope and terms for data use. Most datasets allow \"General Research Use\" unless otherwise specified." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     skos:prefLabel "dataUseModifiers" ;
     linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/PortalDataset> ;
@@ -4269,6 +4276,16 @@
     linkml:range <https://w3id.org/synapse/nfosi/vocab/DataCatalogEnum> ;
     linkml:slot_uri <https://w3id.org/synapse/nfosi/vocab/includedInDataCatalog> .
 
+<https://w3id.org/synapse/nfosi/vocab/portalDataset__individualCount> a linkml:SlotDefinition ;
+    dcterms:title "Individual Count" ;
+    skos:definition "Number of unique individuals included in the dataset (whether as individual-level or as aggregate data). Omit if not applicable/unknown." ;
+    skos:inScheme <https://w3id.org/nfosi/> ;
+    skos:prefLabel "individualCount" ;
+    linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/PortalDataset> ;
+    linkml:owner <https://w3id.org/synapse/nfosi/vocab/PortalDataset> ;
+    linkml:range <https://w3id.org/synapse/nfosi/vocab/integer> ;
+    linkml:slot_uri <https://w3id.org/synapse/nfosi/vocab/individualCount> .
+
 <https://w3id.org/synapse/nfosi/vocab/portalDataset__keywords> a linkml:SlotDefinition ;
     dcterms:title "Keywords" ;
     skos:inScheme <https://w3id.org/nfosi/> ;
@@ -4304,7 +4321,7 @@
 
 <https://w3id.org/synapse/nfosi/vocab/portalDataset__measurementTechnique> a linkml:SlotDefinition ;
     dcterms:title "Measurement Technique" ;
-    skos:definition "Assay used to generate original data. Omit if not applicable (e.g. for curated dataset such as a list compounds from a database or text extracted from Wikipedia)." ;
+    skos:definition "What's used to generate original data, typically referring to the assay. Omit if not applicable (e.g. for curated dataset such as a list compounds from a database or text extracted from Wikipedia)." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     skos:prefLabel "measurementTechnique" ;
     linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/PortalDataset> ;
@@ -4332,6 +4349,16 @@
     linkml:owner <https://w3id.org/synapse/nfosi/vocab/PortalDataset> ;
     linkml:range <https://w3id.org/synapse/nfosi/vocab/SpeciesEnum> ;
     linkml:slot_uri <https://w3id.org/synapse/nfosi/vocab/species> .
+
+<https://w3id.org/synapse/nfosi/vocab/portalDataset__specimenCount> a linkml:SlotDefinition ;
+    dcterms:title "Specimen Count" ;
+    skos:definition "Number of unique specimens included in the dataset. Omit if not applicable/unknown." ;
+    skos:inScheme <https://w3id.org/nfosi/> ;
+    skos:prefLabel "specimenCount" ;
+    linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/PortalDataset> ;
+    linkml:owner <https://w3id.org/synapse/nfosi/vocab/PortalDataset> ;
+    linkml:range <https://w3id.org/synapse/nfosi/vocab/integer> ;
+    linkml:slot_uri <https://w3id.org/synapse/nfosi/vocab/specimenCount> .
 
 <https://w3id.org/synapse/nfosi/vocab/portalDataset__studyId> a linkml:SlotDefinition ;
     dcterms:title "Study ID" ;
@@ -4378,7 +4405,7 @@
 
 <https://w3id.org/synapse/nfosi/vocab/portalDataset__yearProcessed> a linkml:SlotDefinition ;
     dcterms:title "Year Processed" ;
-    skos:definition "Year data were processed. Only for processed data type and when data series is \"NF-OSI Processed Data\"; omit if not applicable/unknown." ;
+    skos:definition "Year data were processed. Only for processed dataset type and when data series is \"NF-OSI Processed Data\"; omit if not applicable/unknown." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     skos:prefLabel "yearProcessed" ;
     linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/PortalDataset> ;
@@ -4660,6 +4687,11 @@
 <https://w3id.org/synapse/nfosi/vocab/small%20molecule%20library%20screen> skos:definition "",
         "High throughput sample analysis of small molecules for purpose such as drug discovery, or biochemical, genetic or pharmacological tests." ;
     linkml:meaning <http://purl.obolibrary.org/obo/ERO_0001726> .
+
+<https://w3id.org/synapse/nfosi/vocab/specimenCount> a linkml:SlotDefinition ;
+    dcterms:title "Specimen Count" ;
+    skos:definition "Number of unique specimens included in the dataset. Omit if not applicable/unknown." ;
+    linkml:range <https://w3id.org/synapse/nfosi/vocab/integer> .
 
 <https://w3id.org/synapse/nfosi/vocab/subject> a linkml:SlotDefinition ;
     dcterms:title "Subject" ;
@@ -7728,7 +7760,7 @@
     dcterms:title "Contributor(s)" ;
     rdfs:seeAlso <https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#contributor> ;
     skos:definition "An entity responsible for making contributions to the resource.",
-        "Organization(s) or person(s) that contributed to the dataset." ;
+        "Properly formatted name of organization(s) or person(s) that contributed to the dataset." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     linkml:definition_uri <https://w3id.org/synapse/nfosi/vocab/contributor> ;
     linkml:multivalued true ;
@@ -7739,7 +7771,7 @@
     dcterms:title "Creator" ;
     rdfs:seeAlso <https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#creator> ;
     skos:definition "An entity responsible for making the resource.",
-        "Organization or person that is creator of the dataset. Default is the PI of the project and/or the user who created all files in the dataset." ;
+        "Properly formatted name of the organization or person that is creator of the dataset (e.g. \"NF-OSI\" or \"Robert Allaway\"), not an id. Default is the project PI and/or the user who created all files/records." ;
     skos:editorialNote "Recommended practice is to identify the creator with a URI. If this is not possible or feasible, a literal value that identifies the creator may be provided." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     linkml:definition_uri <https://w3id.org/synapse/nfosi/vocab/creator> ;
@@ -8000,7 +8032,7 @@
 
 <https://w3id.org/synapse/nfosi/vocab/yearProcessed> a linkml:SlotDefinition ;
     dcterms:title "Year Processed" ;
-    skos:definition "Year data were processed. Only for processed data type and when data series is \"NF-OSI Processed Data\"; omit if not applicable/unknown.",
+    skos:definition "Year data were processed. Only for processed dataset type and when data series is \"NF-OSI Processed Data\"; omit if not applicable/unknown.",
         """Year in which the resource was processed/derived, if applicable.  This is only required for data processed by NF-OSI for tracking purposes, optional for community-contributed datasets. 
 """ ;
     skos:editorialNote "There is no 'year' validation rule and `date` rule requires actual date format" ;
@@ -8759,16 +8791,6 @@
     linkml:range <https://w3id.org/synapse/nfosi/vocab/string> ;
     linkml:slot_uri <https://w3id.org/synapse/nfosi/vocab/assayTarget> .
 
-<https://w3id.org/synapse/nfosi/vocab/integer> a linkml:TypeDefinition ;
-    skos:definition "An integer" ;
-    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"integer\"." ;
-    skos:exactMatch schema1:Integer ;
-    skos:inScheme linkml:types ;
-    linkml:base "int" ;
-    linkml:definition_uri linkml:Integer ;
-    linkml:imported_from "linkml:types" ;
-    linkml:uri xsd:integer .
-
 <https://w3id.org/synapse/nfosi/vocab/workflow> a linkml:SlotDefinition ;
     skos:definition "Name and version of the workflow used to generate/analyze the data" ;
     skos:inScheme <https://w3id.org/nfosi/> ;
@@ -9214,6 +9236,16 @@
     linkml:owner <https://w3id.org/synapse/nfosi/vocab/ElectrophysiologyAssayTemplate> ;
     linkml:range <https://w3id.org/synapse/nfosi/vocab/TimeUnit> ;
     linkml:slot_uri <https://w3id.org/synapse/nfosi/vocab/timepointUnit> .
+
+<https://w3id.org/synapse/nfosi/vocab/integer> a linkml:TypeDefinition ;
+    skos:definition "An integer" ;
+    skos:editorialNote "If you are authoring schemas in LinkML YAML, the type is referenced with the lower case \"integer\"." ;
+    skos:exactMatch schema1:Integer ;
+    skos:inScheme linkml:types ;
+    linkml:base "int" ;
+    linkml:definition_uri linkml:Integer ;
+    linkml:imported_from "linkml:types" ;
+    linkml:uri xsd:integer .
 
 <https://w3id.org/synapse/nfosi/vocab/PdxGenomicsAssayTemplate> a linkml:ClassDefinition ;
     skos:definition "Raw genomics data from patient-derived xenograft (PDX) experiment, with additional PDX-relevant metadata." ;
@@ -10154,11 +10186,11 @@
     skos:definition "Phenotypic expression of chromosomal makeup that defines a study subject as male, female, or other." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     linkml:any_of [ a linkml:AnonymousSlotExpression ;
-            linkml:range <https://w3id.org/synapse/nfosi/vocab/SexEnum> ],
+            linkml:range <https://w3id.org/synapse/nfosi/vocab/UnknownEnum> ],
         [ a linkml:AnonymousSlotExpression ;
             linkml:range <https://w3id.org/synapse/nfosi/vocab/NotApplicableEnum> ],
         [ a linkml:AnonymousSlotExpression ;
-            linkml:range <https://w3id.org/synapse/nfosi/vocab/UnknownEnum> ] ;
+            linkml:range <https://w3id.org/synapse/nfosi/vocab/SexEnum> ] ;
     linkml:definition_uri <https://w3id.org/synapse/nfosi/vocab/sex> ;
     linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/AnimalIndividualTemplate>,
         <https://w3id.org/synapse/nfosi/vocab/BiologicalAssayDataTemplate>,
@@ -10372,7 +10404,7 @@
     dcterms:title "Data Type" ;
     skos:definition """Links an entity to data types that the entity represents/contains. This is closely tied to the assay property. For example, a file of dataType `genomicVariants` might have an assay value of `whole genome sequencing`.
 """,
-        "Reflects the data types of files within the dataset." ;
+        "Reflects the data types within the dataset." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     linkml:any_of [ a linkml:AnonymousSlotExpression ;
             linkml:range <https://w3id.org/synapse/nfosi/vocab/Metadata> ],
@@ -10409,12 +10441,14 @@
         <https://w3id.org/synapse/nfosi/vocab/diseaseFocus>,
         <https://w3id.org/synapse/nfosi/vocab/funder>,
         <https://w3id.org/synapse/nfosi/vocab/includedInDataCatalog>,
+        <https://w3id.org/synapse/nfosi/vocab/individualCount>,
         <https://w3id.org/synapse/nfosi/vocab/keywords>,
         <https://w3id.org/synapse/nfosi/vocab/license>,
         <https://w3id.org/synapse/nfosi/vocab/manifestation>,
         <https://w3id.org/synapse/nfosi/vocab/measurementTechnique>,
         <https://w3id.org/synapse/nfosi/vocab/series>,
         <https://w3id.org/synapse/nfosi/vocab/species>,
+        <https://w3id.org/synapse/nfosi/vocab/specimenCount>,
         <https://w3id.org/synapse/nfosi/vocab/studyId>,
         <https://w3id.org/synapse/nfosi/vocab/subject>,
         <https://w3id.org/synapse/nfosi/vocab/title>,
@@ -10436,12 +10470,14 @@
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__diseaseFocus>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__funder>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__includedInDataCatalog>,
+        <https://w3id.org/synapse/nfosi/vocab/portalDataset__individualCount>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__keywords>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__license>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__manifestation>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__measurementTechnique>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__series>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__species>,
+        <https://w3id.org/synapse/nfosi/vocab/portalDataset__specimenCount>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__studyId>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__subject>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__title>,

--- a/NF.ttl
+++ b/NF.ttl
@@ -12,22 +12,22 @@
 
 <https://w3id.org/synapse/nfosi/vocab/nfosi> a linkml:SchemaDefinition ;
     dcterms:license "https://creativecommons.org/publicdomain/zero/1.0/" ;
-    sh:declare [ sh:namespace rdfs: ;
-            sh:prefix "rdfs" ],
-        [ sh:namespace <https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld> ;
+    sh:declare [ sh:namespace <https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld> ;
             sh:prefix "htan" ],
-        [ sh:namespace linkml: ;
-            sh:prefix "linkml" ],
-        [ sh:namespace skos: ;
-            sh:prefix "skos" ],
-        [ sh:namespace schema1: ;
-            sh:prefix "schema" ],
         [ sh:namespace <https://w3id.org/synapse/nfosi/vocab/> ;
             sh:prefix "nf" ],
         [ sh:namespace prov: ;
             sh:prefix "prov" ],
+        [ sh:namespace schema1: ;
+            sh:prefix "schema" ],
+        [ sh:namespace rdfs: ;
+            sh:prefix "rdfs" ],
         [ sh:namespace <https://w3id.org/linkml/examples/personinfo/> ;
-            sh:prefix "personinfo" ] ;
+            sh:prefix "personinfo" ],
+        [ sh:namespace skos: ;
+            sh:prefix "skos" ],
+        [ sh:namespace linkml: ;
+            sh:prefix "linkml" ] ;
     linkml:classes <https://w3id.org/synapse/nfosi/vocab/AnimalIndividualTemplate>,
         <https://w3id.org/synapse/nfosi/vocab/BiologicalAssayDataTemplate>,
         <https://w3id.org/synapse/nfosi/vocab/BiospecimenTemplate>,
@@ -169,7 +169,7 @@
         <https://w3id.org/synapse/nfosi/vocab/WHOPerformanceStatusScores>,
         <https://w3id.org/synapse/nfosi/vocab/WorkflowEnum>,
         <https://w3id.org/synapse/nfosi/vocab/WorkingDistanceUnitEnum> ;
-    linkml:generation_date "2025-03-20T17:35:19"^^xsd:dateTime ;
+    linkml:generation_date "2025-03-20T20:03:33"^^xsd:dateTime ;
     linkml:id <https://w3id.org/nfosi/> ;
     linkml:imports linkml:types ;
     linkml:metamodel_version "1.7.0" ;
@@ -464,8 +464,8 @@
         <https://w3id.org/synapse/nfosi/vocab/yearProcessed>,
         <https://w3id.org/synapse/nfosi/vocab/yearPublished> ;
     linkml:source_file "NF.yaml" ;
-    linkml:source_file_date "2025-03-20T17:35:17"^^xsd:dateTime ;
-    linkml:source_file_size 298838 ;
+    linkml:source_file_date "2025-03-20T20:03:31"^^xsd:dateTime ;
+    linkml:source_file_size 298781 ;
     linkml:types <https://w3id.org/synapse/nfosi/vocab/boolean>,
         <https://w3id.org/synapse/nfosi/vocab/curie>,
         <https://w3id.org/synapse/nfosi/vocab/date>,
@@ -4181,7 +4181,7 @@
 
 <https://w3id.org/synapse/nfosi/vocab/portalDataset__contributor> a linkml:SlotDefinition ;
     dcterms:title "Contributor(s)" ;
-    skos:definition "Institution of person repsonsible for collecting and managing data. Properly formatted name of organization(s) or person(s) that contributed to the dataset." ;
+    skos:definition "Institution or person responsible for collecting and managing the files and records in the dataset." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     skos:prefLabel "contributor" ;
     linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/PortalDataset> ;
@@ -7760,7 +7760,7 @@
     dcterms:title "Contributor(s)" ;
     rdfs:seeAlso <https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#contributor> ;
     skos:definition "An entity responsible for making contributions to the resource.",
-        "Institution of person repsonsible for collecting and managing data. Properly formatted name of organization(s) or person(s) that contributed to the dataset." ;
+        "Institution or person responsible for collecting and managing the files and records in the dataset." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     linkml:definition_uri <https://w3id.org/synapse/nfosi/vocab/contributor> ;
     linkml:multivalued true ;
@@ -10119,9 +10119,9 @@
     skos:definition "A group of presumed common ancestry with clear-cut physiological but usually not morphological distinctions such as an animal model or cell line. EXAMPLE(S):  HEK293 (cell line), Minnesota5 (swine strain), DXL (poultry strain), RB51 (vaccine strain of Brucella abortus)" ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     linkml:any_of [ a linkml:AnonymousSlotExpression ;
-            linkml:range <https://w3id.org/synapse/nfosi/vocab/CellLineModel> ],
+            linkml:range <https://w3id.org/synapse/nfosi/vocab/MouseModel> ],
         [ a linkml:AnonymousSlotExpression ;
-            linkml:range <https://w3id.org/synapse/nfosi/vocab/MouseModel> ] ;
+            linkml:range <https://w3id.org/synapse/nfosi/vocab/CellLineModel> ] ;
     linkml:definition_uri <https://w3id.org/synapse/nfosi/vocab/modelSystemName> ;
     linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/AnimalIndividualTemplate>,
         <https://w3id.org/synapse/nfosi/vocab/BiologicalAssayDataTemplate>,
@@ -10183,9 +10183,9 @@
     skos:definition "Genotype of NF1 gene in the biospecimen from which the data were derived, if known." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     linkml:any_of [ a linkml:AnonymousSlotExpression ;
-            linkml:range <https://w3id.org/synapse/nfosi/vocab/Genotype> ],
+            linkml:range <https://w3id.org/synapse/nfosi/vocab/UnknownEnum> ],
         [ a linkml:AnonymousSlotExpression ;
-            linkml:range <https://w3id.org/synapse/nfosi/vocab/UnknownEnum> ] ;
+            linkml:range <https://w3id.org/synapse/nfosi/vocab/Genotype> ] ;
     linkml:definition_uri <https://w3id.org/synapse/nfosi/vocab/nf1Genotype> ;
     linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/AnimalIndividualTemplate>,
         <https://w3id.org/synapse/nfosi/vocab/BiologicalAssayDataTemplate>,
@@ -10198,9 +10198,9 @@
     skos:definition "Phenotypic expression of chromosomal makeup that defines a study subject as male, female, or other." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     linkml:any_of [ a linkml:AnonymousSlotExpression ;
-            linkml:range <https://w3id.org/synapse/nfosi/vocab/NotApplicableEnum> ],
-        [ a linkml:AnonymousSlotExpression ;
             linkml:range <https://w3id.org/synapse/nfosi/vocab/SexEnum> ],
+        [ a linkml:AnonymousSlotExpression ;
+            linkml:range <https://w3id.org/synapse/nfosi/vocab/NotApplicableEnum> ],
         [ a linkml:AnonymousSlotExpression ;
             linkml:range <https://w3id.org/synapse/nfosi/vocab/UnknownEnum> ] ;
     linkml:definition_uri <https://w3id.org/synapse/nfosi/vocab/sex> ;

--- a/NF.ttl
+++ b/NF.ttl
@@ -12,22 +12,22 @@
 
 <https://w3id.org/synapse/nfosi/vocab/nfosi> a linkml:SchemaDefinition ;
     dcterms:license "https://creativecommons.org/publicdomain/zero/1.0/" ;
-    sh:declare [ sh:namespace <https://w3id.org/synapse/nfosi/vocab/> ;
+    sh:declare [ sh:namespace rdfs: ;
+            sh:prefix "rdfs" ],
+        [ sh:namespace <https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld> ;
+            sh:prefix "htan" ],
+        [ sh:namespace linkml: ;
+            sh:prefix "linkml" ],
+        [ sh:namespace skos: ;
+            sh:prefix "skos" ],
+        [ sh:namespace schema1: ;
+            sh:prefix "schema" ],
+        [ sh:namespace <https://w3id.org/synapse/nfosi/vocab/> ;
             sh:prefix "nf" ],
         [ sh:namespace prov: ;
             sh:prefix "prov" ],
-        [ sh:namespace rdfs: ;
-            sh:prefix "rdfs" ],
-        [ sh:namespace linkml: ;
-            sh:prefix "linkml" ],
         [ sh:namespace <https://w3id.org/linkml/examples/personinfo/> ;
-            sh:prefix "personinfo" ],
-        [ sh:namespace <https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld> ;
-            sh:prefix "htan" ],
-        [ sh:namespace schema1: ;
-            sh:prefix "schema" ],
-        [ sh:namespace skos: ;
-            sh:prefix "skos" ] ;
+            sh:prefix "personinfo" ] ;
     linkml:classes <https://w3id.org/synapse/nfosi/vocab/AnimalIndividualTemplate>,
         <https://w3id.org/synapse/nfosi/vocab/BiologicalAssayDataTemplate>,
         <https://w3id.org/synapse/nfosi/vocab/BiospecimenTemplate>,
@@ -169,7 +169,7 @@
         <https://w3id.org/synapse/nfosi/vocab/WHOPerformanceStatusScores>,
         <https://w3id.org/synapse/nfosi/vocab/WorkflowEnum>,
         <https://w3id.org/synapse/nfosi/vocab/WorkingDistanceUnitEnum> ;
-    linkml:generation_date "2025-03-19T16:20:02"^^xsd:dateTime ;
+    linkml:generation_date "2025-03-20T17:35:19"^^xsd:dateTime ;
     linkml:id <https://w3id.org/nfosi/> ;
     linkml:imports linkml:types ;
     linkml:metamodel_version "1.7.0" ;
@@ -330,6 +330,7 @@
         <https://w3id.org/synapse/nfosi/vocab/populationCoverage>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__accessType>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__alternateName>,
+        <https://w3id.org/synapse/nfosi/vocab/portalDataset__citation>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__conditionsOfAccess>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__contributor>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__countryOfOrigin>,
@@ -463,8 +464,8 @@
         <https://w3id.org/synapse/nfosi/vocab/yearProcessed>,
         <https://w3id.org/synapse/nfosi/vocab/yearPublished> ;
     linkml:source_file "NF.yaml" ;
-    linkml:source_file_date "2025-03-19T16:20:01"^^xsd:dateTime ;
-    linkml:source_file_size 298524 ;
+    linkml:source_file_date "2025-03-20T17:35:17"^^xsd:dateTime ;
+    linkml:source_file_size 298838 ;
     linkml:types <https://w3id.org/synapse/nfosi/vocab/boolean>,
         <https://w3id.org/synapse/nfosi/vocab/curie>,
         <https://w3id.org/synapse/nfosi/vocab/date>,
@@ -4158,6 +4159,16 @@
     linkml:range <https://w3id.org/synapse/nfosi/vocab/string> ;
     linkml:slot_uri <https://w3id.org/synapse/nfosi/vocab/alternateName> .
 
+<https://w3id.org/synapse/nfosi/vocab/portalDataset__citation> a linkml:SlotDefinition ;
+    dcterms:title "Citation" ;
+    skos:definition "identifies academic articles that are recommended by the data provider be cited in addition to the dataset itself." ;
+    skos:inScheme <https://w3id.org/nfosi/> ;
+    skos:prefLabel "citation" ;
+    linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/PortalDataset> ;
+    linkml:owner <https://w3id.org/synapse/nfosi/vocab/PortalDataset> ;
+    linkml:range <https://w3id.org/synapse/nfosi/vocab/string> ;
+    linkml:slot_uri <https://w3id.org/synapse/nfosi/vocab/citation> .
+
 <https://w3id.org/synapse/nfosi/vocab/portalDataset__conditionsOfAccess> a linkml:SlotDefinition ;
     dcterms:title "User Specific Restriction" ;
     skos:definition "Additional requirements a user may need outside of Data Use Modifiers. This could include additional registration, updating profile information, joining a Synapse Team, or using specific authentication methods like 2FA or RAS. Omit property if not applicable/unknown." ;
@@ -4170,7 +4181,7 @@
 
 <https://w3id.org/synapse/nfosi/vocab/portalDataset__contributor> a linkml:SlotDefinition ;
     dcterms:title "Contributor(s)" ;
-    skos:definition "Properly formatted name of organization(s) or person(s) that contributed to the dataset." ;
+    skos:definition "Institution of person repsonsible for collecting and managing data. Properly formatted name of organization(s) or person(s) that contributed to the dataset." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     skos:prefLabel "contributor" ;
     linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/PortalDataset> ;
@@ -7707,17 +7718,6 @@
     linkml:required true ;
     linkml:slot_uri <https://w3id.org/synapse/nfosi/vocab/channel> .
 
-<https://w3id.org/synapse/nfosi/vocab/citation> a linkml:SlotDefinition ;
-    dcterms:title "Citation" ;
-    skos:definition "Citation (e.g. doi) that usage of data or resource should be cited with." ;
-    skos:inScheme <https://w3id.org/nfosi/> ;
-    linkml:definition_uri <https://w3id.org/synapse/nfosi/vocab/citation> ;
-    linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/Protocol>,
-        <https://w3id.org/synapse/nfosi/vocab/SourceCodeTemplate> ;
-    linkml:owner <https://w3id.org/synapse/nfosi/vocab/SourceCodeTemplate> ;
-    linkml:range <https://w3id.org/synapse/nfosi/vocab/string> ;
-    linkml:slot_uri <https://w3id.org/synapse/nfosi/vocab/citation> .
-
 <https://w3id.org/synapse/nfosi/vocab/concentrationMaterial> a linkml:SlotDefinition ;
     skos:definition "Numeric value for concentration of the material" ;
     skos:inScheme <https://w3id.org/nfosi/> ;
@@ -7760,7 +7760,7 @@
     dcterms:title "Contributor(s)" ;
     rdfs:seeAlso <https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#contributor> ;
     skos:definition "An entity responsible for making contributions to the resource.",
-        "Properly formatted name of organization(s) or person(s) that contributed to the dataset." ;
+        "Institution of person repsonsible for collecting and managing data. Properly formatted name of organization(s) or person(s) that contributed to the dataset." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     linkml:definition_uri <https://w3id.org/synapse/nfosi/vocab/contributor> ;
     linkml:multivalued true ;
@@ -8629,6 +8629,18 @@
     linkml:range <https://w3id.org/synapse/nfosi/vocab/Cell> ;
     linkml:slot_uri <https://w3id.org/synapse/nfosi/vocab/cellType> .
 
+<https://w3id.org/synapse/nfosi/vocab/citation> a linkml:SlotDefinition ;
+    dcterms:title "Citation" ;
+    skos:definition "Citation (e.g. doi) that usage of data or resource should be cited with.",
+        "identifies academic articles that are recommended by the data provider be cited in addition to the dataset itself." ;
+    skos:inScheme <https://w3id.org/nfosi/> ;
+    linkml:definition_uri <https://w3id.org/synapse/nfosi/vocab/citation> ;
+    linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/Protocol>,
+        <https://w3id.org/synapse/nfosi/vocab/SourceCodeTemplate> ;
+    linkml:owner <https://w3id.org/synapse/nfosi/vocab/SourceCodeTemplate> ;
+    linkml:range <https://w3id.org/synapse/nfosi/vocab/string> ;
+    linkml:slot_uri <https://w3id.org/synapse/nfosi/vocab/citation> .
+
 <https://w3id.org/synapse/nfosi/vocab/compoundDose> a linkml:SlotDefinition ;
     skos:definition "A dose quantity for the treatment compound. To be used with compoundDoseUnit." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
@@ -9338,9 +9350,9 @@
 """ ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     linkml:any_of [ a linkml:AnonymousSlotExpression ;
-            linkml:range <https://w3id.org/synapse/nfosi/vocab/Tissue> ],
+            linkml:range <https://w3id.org/synapse/nfosi/vocab/OrganismSubstance> ],
         [ a linkml:AnonymousSlotExpression ;
-            linkml:range <https://w3id.org/synapse/nfosi/vocab/OrganismSubstance> ] ;
+            linkml:range <https://w3id.org/synapse/nfosi/vocab/Tissue> ] ;
     linkml:definition_uri <https://w3id.org/synapse/nfosi/vocab/specimenType> ;
     linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/BulkSequencingAssayTemplate> ;
     linkml:owner <https://w3id.org/synapse/nfosi/vocab/BulkSequencingAssayTemplate> ;
@@ -10107,9 +10119,9 @@
     skos:definition "A group of presumed common ancestry with clear-cut physiological but usually not morphological distinctions such as an animal model or cell line. EXAMPLE(S):  HEK293 (cell line), Minnesota5 (swine strain), DXL (poultry strain), RB51 (vaccine strain of Brucella abortus)" ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     linkml:any_of [ a linkml:AnonymousSlotExpression ;
-            linkml:range <https://w3id.org/synapse/nfosi/vocab/MouseModel> ],
+            linkml:range <https://w3id.org/synapse/nfosi/vocab/CellLineModel> ],
         [ a linkml:AnonymousSlotExpression ;
-            linkml:range <https://w3id.org/synapse/nfosi/vocab/CellLineModel> ] ;
+            linkml:range <https://w3id.org/synapse/nfosi/vocab/MouseModel> ] ;
     linkml:definition_uri <https://w3id.org/synapse/nfosi/vocab/modelSystemName> ;
     linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/AnimalIndividualTemplate>,
         <https://w3id.org/synapse/nfosi/vocab/BiologicalAssayDataTemplate>,
@@ -10186,11 +10198,11 @@
     skos:definition "Phenotypic expression of chromosomal makeup that defines a study subject as male, female, or other." ;
     skos:inScheme <https://w3id.org/nfosi/> ;
     linkml:any_of [ a linkml:AnonymousSlotExpression ;
-            linkml:range <https://w3id.org/synapse/nfosi/vocab/UnknownEnum> ],
-        [ a linkml:AnonymousSlotExpression ;
             linkml:range <https://w3id.org/synapse/nfosi/vocab/NotApplicableEnum> ],
         [ a linkml:AnonymousSlotExpression ;
-            linkml:range <https://w3id.org/synapse/nfosi/vocab/SexEnum> ] ;
+            linkml:range <https://w3id.org/synapse/nfosi/vocab/SexEnum> ],
+        [ a linkml:AnonymousSlotExpression ;
+            linkml:range <https://w3id.org/synapse/nfosi/vocab/UnknownEnum> ] ;
     linkml:definition_uri <https://w3id.org/synapse/nfosi/vocab/sex> ;
     linkml:domain_of <https://w3id.org/synapse/nfosi/vocab/AnimalIndividualTemplate>,
         <https://w3id.org/synapse/nfosi/vocab/BiologicalAssayDataTemplate>,
@@ -10430,6 +10442,7 @@
     skos:inScheme <https://w3id.org/nfosi/> ;
     linkml:attributes <https://w3id.org/synapse/nfosi/vocab/accessType>,
         <https://w3id.org/synapse/nfosi/vocab/alternateName>,
+        <https://w3id.org/synapse/nfosi/vocab/citation>,
         <https://w3id.org/synapse/nfosi/vocab/conditionsOfAccess>,
         <https://w3id.org/synapse/nfosi/vocab/contributor>,
         <https://w3id.org/synapse/nfosi/vocab/countryOfOrigin>,
@@ -10459,6 +10472,7 @@
     linkml:slot_usage [ ] ;
     linkml:slots <https://w3id.org/synapse/nfosi/vocab/portalDataset__accessType>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__alternateName>,
+        <https://w3id.org/synapse/nfosi/vocab/portalDataset__citation>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__conditionsOfAccess>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__contributor>,
         <https://w3id.org/synapse/nfosi/vocab/portalDataset__countryOfOrigin>,

--- a/NF.yaml
+++ b/NF.yaml
@@ -5343,7 +5343,7 @@ classes:
       # - id
       # - count
       # - currentVersion
-      # - doi (if minted)
+      # - doi (if minted) (written as identifier)
       # - createdBy # user id/handle, creator allows setting name more explicitly for citations
       # - datasetItemCount
       # - datasetSizeInBytes
@@ -5352,6 +5352,11 @@ classes:
         title: Title
         range: string
         required: true
+      description:
+        title: Description
+        range: string
+        description: Blurb for the dataset; should be no more than 500 characters.
+        required: false
       alternateName:
         title: Alternate Name
         description: An altername name that can be used for search and discovery improvement.
@@ -5365,30 +5370,14 @@ classes:
       contributor:
         title: Contributor(s)
         range: string
-        description: Properly formatted name of organization(s) or person(s) that contributed to the dataset.
+        description: Institution of person repsonsible for collecting and managing data. Properly formatted name of organization(s) or person(s) that contributed to the dataset.
         multivalued: true
         required: false
-      description:
-        title: Description
+      studyId:
+        title: Study ID
         range: string
-        description: Blurb for the dataset; should be no more than 500 characters.
-        required: false
-      accessType:
-        title: Access Type
-        range: AccessTypeEnum
-        description: Access type for the dataset.
+        description: Identifier for the study (project) from which the dataset was derived.
         required: true
-      license:
-        title: License
-        range: License
-        description: Unless information for license is clear, this should default to UNKNOWN.
-        required: true
-      countryOfOrigin:
-        title: Country of Origin
-        range: string
-        description: Origin of individuals from which data were generated. Omit if not applicable/unknown.
-        multivalued: true
-        required: false
       measurementTechnique:
         title: Measurement Technique
         range: AssayEnum
@@ -5416,11 +5405,6 @@ classes:
         description: Species of the organism(s) from which the data were generated. Omit property if not applicable, such as for data like compounds or other non-biological data.
         multivalued: true
         required: false # not all datasets from assays that use biological samples
-      studyId:
-        title: Study ID
-        range: string
-        description: Identifier for the study (project) from which the dataset was derived.
-        required: true
       manifestation:
         title: Manifestation(s)
         range: ManifestationEnum
@@ -5473,6 +5457,27 @@ classes:
         description: Link(s) to known data catalog(s) the dataset is included in.
         range: DataCatalogEnum
         required: false
+      citation:
+        title: Citation
+        range: string
+        description: identifies academic articles that are recommended by the data provider be cited in addition to the dataset itself.
+        required: false
+      countryOfOrigin:
+        title: Country of Origin
+        range: string
+        description: Origin of individuals from which data were generated. Omit if not applicable/unknown.
+        multivalued: true
+        required: false
+      accessType:
+        title: Access Type
+        range: AccessTypeEnum
+        description: Access type for the dataset.
+        required: true
+      license:
+        title: License
+        range: License
+        description: Unless information for license is clear, this should default to UNKNOWN.
+        required: true
       dataUseModifiers:
         title: Data Use Modifiers
         description: List of data use ontology (DUO) terms that are true for dataset, which describes the allowable scope and terms for data use. Most datasets allow "General Research Use" unless otherwise specified.

--- a/NF.yaml
+++ b/NF.yaml
@@ -5370,7 +5370,7 @@ classes:
       contributor:
         title: Contributor(s)
         range: string
-        description: Institution of person repsonsible for collecting and managing data. Properly formatted name of organization(s) or person(s) that contributed to the dataset.
+        description: Institution or person responsible for collecting and managing the files and records in the dataset.
         multivalued: true
         required: false
       studyId:

--- a/NF.yaml
+++ b/NF.yaml
@@ -5360,12 +5360,12 @@ classes:
       creator:
         title: Creator
         range: string
-        description: Organization or person that is creator of the dataset. Default is the PI of the project and/or the user who created all files in the dataset.
+        description: Properly formatted name of the organization or person that is creator of the dataset (e.g. "NF-OSI" or "Robert Allaway"), not an id. Default is the project PI and/or the user who created all files/records.
         required: true
       contributor:
         title: Contributor(s)
         range: string
-        description: Organization(s) or person(s) that contributed to the dataset.
+        description: Properly formatted name of organization(s) or person(s) that contributed to the dataset.
         multivalued: true
         required: false
       description:
@@ -5392,7 +5392,7 @@ classes:
       measurementTechnique:
         title: Measurement Technique
         range: AssayEnum
-        description: Assay used to generate original data. Omit if not applicable (e.g. for curated dataset such as a list compounds from a database or text extracted from Wikipedia).
+        description: What's used to generate original data, typically referring to the assay. Omit if not applicable (e.g. for curated dataset such as a list compounds from a database or text extracted from Wikipedia).
       keywords:
         title: Keywords
         range: string
@@ -5407,7 +5407,7 @@ classes:
       dataType:
         title: Data Type
         range: Data
-        description: Reflects the data types of files within the dataset.
+        description: Reflects the data types within the dataset.
         multivalued: true
         required: true
       species:
@@ -5437,6 +5437,16 @@ classes:
         range: FundingAgencyEnum
         multivalued: true
         required: true
+      individualCount:
+        title: Individual Count
+        range: integer
+        description: Number of unique individuals included in the dataset (whether as individual-level or as aggregate data). Omit if not applicable/unknown.
+        required: false
+      specimenCount:
+        title: Specimen Count
+        range: integer
+        description: Number of unique specimens included in the dataset. Omit if not applicable/unknown.
+        required: false
       series:
         title: Data Series
         range: DataSeriesEnum
@@ -5450,7 +5460,7 @@ classes:
         required: false
       yearProcessed:
         title: Year Processed
-        description: Year data were processed. Only for processed data type and when data series is "NF-OSI Processed Data"; omit if not applicable/unknown.
+        description: Year data were processed. Only for processed dataset type and when data series is "NF-OSI Processed Data"; omit if not applicable/unknown.
         range: integer
         required: false
       datePublished:
@@ -5465,7 +5475,7 @@ classes:
         required: false
       dataUseModifiers:
         title: Data Use Modifiers
-        description: List of data use ontology (DUO) terms that are true for dataset, which describes the allowable scope and terms for data use. Omit property if not applicable/unknown.
+        description: List of data use ontology (DUO) terms that are true for dataset, which describes the allowable scope and terms for data use. Most datasets allow "General Research Use" unless otherwise specified.
         range: DuoEnum
         multivalued: true
         required: false

--- a/modules/Template/PortalDataset.yaml
+++ b/modules/Template/PortalDataset.yaml
@@ -17,7 +17,7 @@ classes:
     # - id
     # - count
     # - currentVersion
-    # - doi (if minted)
+    # - doi (if minted) (written as identifier)
     # - createdBy # user id/handle, creator allows setting name more explicitly for citations
     # - datasetItemCount
     # - datasetSizeInBytes
@@ -26,6 +26,11 @@ classes:
         title: Title
         range: string
         required: true
+      description:
+        title: Description
+        range: string
+        description: Blurb for the dataset; should be no more than 500 characters.
+        required: false
       alternateName:
         title: Alternate Name
         description: An altername name that can be used for search and discovery improvement.
@@ -39,30 +44,14 @@ classes:
       contributor:
         title: Contributor(s)
         range: string
-        description: Properly formatted name of organization(s) or person(s) that contributed to the dataset.
+        description: Institution of person repsonsible for collecting and managing data. Properly formatted name of organization(s) or person(s) that contributed to the dataset.
         multivalued: true
         required: false
-      description:
-        title: Description
+      studyId:
+        title: Study ID
         range: string
-        description: Blurb for the dataset; should be no more than 500 characters.
-        required: false
-      accessType:
-        title: Access Type
-        range: AccessTypeEnum
-        description: Access type for the dataset.
+        description: Identifier for the study (project) from which the dataset was derived.
         required: true
-      license:
-        title: License
-        range: License
-        description: Unless information for license is clear, this should default to UNKNOWN. 
-        required: true
-      countryOfOrigin:
-        title: Country of Origin
-        range: string
-        description: Origin of individuals from which data were generated. Omit if not applicable/unknown.
-        multivalued: true
-        required: false
       measurementTechnique:
         title: Measurement Technique
         range: AssayEnum
@@ -76,7 +65,7 @@ classes:
         title: Subject
         range: string
         description: Applicable subject term(s) for dataset cataloging; use the Library of Congress Subject Headings (LCSH) scheme.
-        multivalued: true 
+        multivalued: true
         required: false
       dataType:
         title: Data Type
@@ -90,11 +79,6 @@ classes:
         description: Species of the organism(s) from which the data were generated. Omit property if not applicable, such as for data like compounds or other non-biological data.
         multivalued: true
         required: false # not all datasets from assays that use biological samples
-      studyId:
-        title: Study ID
-        range: string
-        description: Identifier for the study (project) from which the dataset was derived.
-        required: true
       manifestation:
         title: Manifestation(s)
         range: ManifestationEnum
@@ -124,7 +108,7 @@ classes:
       series:
         title: Data Series
         range: DataSeriesEnum
-        description: Datasets may belong to a curated series. Should be assigned by staff only; omit property if not applicable/unknown. 
+        description: Datasets may belong to a curated series. Should be assigned by staff only; omit property if not applicable/unknown.
         required: false
       visualizeDataOn:
         title: Visualize Data On
@@ -147,6 +131,27 @@ classes:
         description: Link(s) to known data catalog(s) the dataset is included in.
         range: DataCatalogEnum
         required: false
+      citation:
+        title: Citation
+        range: string
+        description: identifies academic articles that are recommended by the data provider be cited in addition to the dataset itself.
+        required: false
+      countryOfOrigin:
+        title: Country of Origin
+        range: string
+        description: Origin of individuals from which data were generated. Omit if not applicable/unknown.
+        multivalued: true
+        required: false
+      accessType:
+        title: Access Type
+        range: AccessTypeEnum
+        description: Access type for the dataset.
+        required: true
+      license:
+        title: License
+        range: License
+        description: Unless information for license is clear, this should default to UNKNOWN.
+        required: true
       dataUseModifiers:
         title: Data Use Modifiers
         description: List of data use ontology (DUO) terms that are true for dataset, which describes the allowable scope and terms for data use. Most datasets allow "General Research Use" unless otherwise specified.

--- a/modules/Template/PortalDataset.yaml
+++ b/modules/Template/PortalDataset.yaml
@@ -44,7 +44,7 @@ classes:
       contributor:
         title: Contributor(s)
         range: string
-        description: Institution of person repsonsible for collecting and managing data. Properly formatted name of organization(s) or person(s) that contributed to the dataset.
+        description: Institution or person responsible for collecting and managing the files and records in the dataset.
         multivalued: true
         required: false
       studyId:

--- a/modules/Template/PortalDataset.yaml
+++ b/modules/Template/PortalDataset.yaml
@@ -111,10 +111,15 @@ classes:
         range: FundingAgencyEnum
         multivalued: true
         required: true
-      populationSize:
-        title: Population Size
+      individualsIncluded:
+        title: Individuals Included
         range: integer
-        description: Number of individuals represented by the dataset (whether as individual-level or as aggregate data). Omit if not applicable/unknown.
+        description: Number of unique individuals included in the dataset (whether as individual-level or as aggregate data). Omit if not applicable/unknown.
+        required: false
+      specimensIncluded:
+        title: Specimens Included
+        range: integer
+        description: Number of unique specimens included in the dataset. Omit if not applicable/unknown.
         required: false
       series:
         title: Data Series

--- a/modules/Template/PortalDataset.yaml
+++ b/modules/Template/PortalDataset.yaml
@@ -111,13 +111,13 @@ classes:
         range: FundingAgencyEnum
         multivalued: true
         required: true
-      individualsIncluded:
-        title: Individuals Included
+      individualCount:
+        title: Individual Count
         range: integer
         description: Number of unique individuals included in the dataset (whether as individual-level or as aggregate data). Omit if not applicable/unknown.
         required: false
-      specimensIncluded:
-        title: Specimens Included
+      specimenCount:
+        title: Specimen Count
         range: integer
         description: Number of unique specimens included in the dataset. Omit if not applicable/unknown.
         required: false

--- a/modules/Template/PortalDataset.yaml
+++ b/modules/Template/PortalDataset.yaml
@@ -34,12 +34,12 @@ classes:
       creator:
         title: Creator
         range: string
-        description: Organization or person that is creator of the dataset. Default is the PI of the project and/or the user who created all files in the dataset.
+        description: Properly formatted name of the organization or person that is creator of the dataset (e.g. "NF-OSI" or "Robert Allaway"), not an id. Default is the project PI and/or the user who created all files/records.
         required: true
       contributor:
         title: Contributor(s)
         range: string
-        description: Organization(s) or person(s) that contributed to the dataset.
+        description: Properly formatted name of organization(s) or person(s) that contributed to the dataset.
         multivalued: true
         required: false
       description:
@@ -66,7 +66,7 @@ classes:
       measurementTechnique:
         title: Measurement Technique
         range: AssayEnum
-        description: Assay used to generate original data. Omit if not applicable (e.g. for curated dataset such as a list compounds from a database or text extracted from Wikipedia).
+        description: What's used to generate original data, typically referring to the assay. Omit if not applicable (e.g. for curated dataset such as a list compounds from a database or text extracted from Wikipedia).
       keywords:
         title: Keywords
         range: string
@@ -81,7 +81,7 @@ classes:
       dataType:
         title: Data Type
         range: Data
-        description: Reflects the data types of files within the dataset.
+        description: Reflects the data types within the dataset.
         multivalued: true
         required: true
       species:
@@ -111,6 +111,11 @@ classes:
         range: FundingAgencyEnum
         multivalued: true
         required: true
+      populationSize:
+        title: Population Size
+        range: integer
+        description: Number of individuals represented by the dataset (whether as individual-level or as aggregate data). Omit if not applicable/unknown.
+        required: false
       series:
         title: Data Series
         range: DataSeriesEnum
@@ -124,7 +129,7 @@ classes:
         required: false
       yearProcessed:
         title: Year Processed
-        description: Year data were processed. Only for processed data type and when data series is "NF-OSI Processed Data"; omit if not applicable/unknown.
+        description: Year data were processed. Only for processed dataset type and when data series is "NF-OSI Processed Data"; omit if not applicable/unknown.
         range: integer
         required: false
       datePublished:
@@ -139,7 +144,7 @@ classes:
         required: false
       dataUseModifiers:
         title: Data Use Modifiers
-        description: List of data use ontology (DUO) terms that are true for dataset, which describes the allowable scope and terms for data use. Omit property if not applicable/unknown.
+        description: List of data use ontology (DUO) terms that are true for dataset, which describes the allowable scope and terms for data use. Most datasets allow "General Research Use" unless otherwise specified.
         range: DuoEnum
         multivalued: true
         required: false

--- a/registered-json-schemas/PortalDataset.json
+++ b/registered-json-schemas/PortalDataset.json
@@ -24,7 +24,7 @@
       "type": "string"
     },
     "contributor": {
-      "description": "Organization(s) or person(s) that contributed to the dataset.",
+      "description": "Properly formatted name of organization(s) or person(s) that contributed to the dataset.",
       "items": {
         "type": "string"
       },
@@ -40,12 +40,12 @@
       "type": "array"
     },
     "creator": {
-      "description": "Organization or person that is creator of the dataset. Default is the PI of the project and/or the user who created all files in the dataset.",
+      "description": "Properly formatted name of the organization or person that is creator of the dataset (e.g. \"NF-OSI\" or \"Robert Allaway\"), not an id. Default is the project PI and/or the user who created all files/records.",
       "title": "Creator",
       "type": "string"
     },
     "dataType": {
-      "description": "Reflects the data types of files within the dataset.",
+      "description": "Reflects the data types within the dataset.",
       "items": {
         "description": "What the data (file) contains.",
         "enum": [
@@ -95,7 +95,7 @@
       "type": "array"
     },
     "dataUseModifiers": {
-      "description": "List of data use ontology (DUO) terms that are true for dataset, which describes the allowable scope and terms for data use. Omit property if not applicable/unknown.",
+      "description": "List of data use ontology (DUO) terms that are true for dataset, which describes the allowable scope and terms for data use. Most datasets allow \"General Research Use\" unless otherwise specified.",
       "items": {
         "description": "",
         "enum": [
@@ -241,7 +241,7 @@
       "type": "array"
     },
     "measurementTechnique": {
-      "description": "Assay used to generate original data. Omit if not applicable (e.g. for curated dataset such as a list compounds from a database or text extracted from Wikipedia).",
+      "description": "What's used to generate original data, typically referring to the assay. Omit if not applicable (e.g. for curated dataset such as a list compounds from a database or text extracted from Wikipedia).",
       "title": "Measurement Technique",
       "enum": [
         "2D AlamarBlue absorbance",
@@ -435,6 +435,11 @@
       ],
       "type": "string"
     },
+    "populationSize": {
+      "description": "Number of individuals represented by the dataset (whether as individual-level or as aggregate data). Omit if not applicable/unknown.",
+      "title": "Population Size",
+      "type": "integer"
+    },
     "series": {
       "description": "Datasets may belong to a curated series. Should be assigned by staff only; omit property if not applicable/unknown.",
       "title": "Data Series",
@@ -492,7 +497,7 @@
       "type": "array"
     },
     "yearProcessed": {
-      "description": "Year data were processed. Only for processed data type and when data series is \"NF-OSI Processed Data\"; omit if not applicable/unknown.",
+      "description": "Year data were processed. Only for processed dataset type and when data series is \"NF-OSI Processed Data\"; omit if not applicable/unknown.",
       "title": "Year Processed",
       "type": "integer"
     }

--- a/registered-json-schemas/PortalDataset.json
+++ b/registered-json-schemas/PortalDataset.json
@@ -18,13 +18,18 @@
       "title": "Alternate Name",
       "type": "string"
     },
+    "citation": {
+      "description": "identifies academic articles that are recommended by the data provider be cited in addition to the dataset itself.",
+      "title": "Citation",
+      "type": "string"
+    },
     "conditionsOfAccess": {
       "description": "Additional requirements a user may need outside of Data Use Modifiers. This could include additional registration, updating profile information, joining a Synapse Team, or using specific authentication methods like 2FA or RAS. Omit property if not applicable/unknown.",
       "title": "User Specific Restriction",
       "type": "string"
     },
     "contributor": {
-      "description": "Properly formatted name of organization(s) or person(s) that contributed to the dataset.",
+      "description": "Institution of person repsonsible for collecting and managing data. Properly formatted name of organization(s) or person(s) that contributed to the dataset.",
       "items": {
         "type": "string"
       },
@@ -510,13 +515,13 @@
   "required": [
     "title",
     "creator",
-    "accessType",
-    "license",
+    "studyId",
     "keywords",
     "dataType",
-    "studyId",
     "diseaseFocus",
-    "funder"
+    "funder",
+    "accessType",
+    "license"
   ],
   "title": "PortalDataset",
   "type": "object",

--- a/registered-json-schemas/PortalDataset.json
+++ b/registered-json-schemas/PortalDataset.json
@@ -183,6 +183,11 @@
       ],
       "type": "string"
     },
+    "individualsIncluded": {
+      "description": "Number of unique individuals included in the dataset (whether as individual-level or as aggregate data). Omit if not applicable/unknown.",
+      "title": "Individuals Included",
+      "type": "integer"
+    },
     "keywords": {
       "items": {
         "type": "string"
@@ -435,11 +440,6 @@
       ],
       "type": "string"
     },
-    "populationSize": {
-      "description": "Number of individuals represented by the dataset (whether as individual-level or as aggregate data). Omit if not applicable/unknown.",
-      "title": "Population Size",
-      "type": "integer"
-    },
     "series": {
       "description": "Datasets may belong to a curated series. Should be assigned by staff only; omit property if not applicable/unknown.",
       "title": "Data Series",
@@ -470,6 +470,11 @@
       },
       "title": "Species",
       "type": "array"
+    },
+    "specimensIncluded": {
+      "description": "Number of unique specimens included in the dataset. Omit if not applicable/unknown.",
+      "title": "Specimens Included",
+      "type": "integer"
     },
     "studyId": {
       "description": "Identifier for the study (project) from which the dataset was derived.",

--- a/registered-json-schemas/PortalDataset.json
+++ b/registered-json-schemas/PortalDataset.json
@@ -183,9 +183,9 @@
       ],
       "type": "string"
     },
-    "individualsIncluded": {
+    "individualCount": {
       "description": "Number of unique individuals included in the dataset (whether as individual-level or as aggregate data). Omit if not applicable/unknown.",
-      "title": "Individuals Included",
+      "title": "Individual Count",
       "type": "integer"
     },
     "keywords": {
@@ -471,9 +471,9 @@
       "title": "Species",
       "type": "array"
     },
-    "specimensIncluded": {
+    "specimenCount": {
       "description": "Number of unique specimens included in the dataset. Omit if not applicable/unknown.",
-      "title": "Specimens Included",
+      "title": "Specimen Count",
       "type": "integer"
     },
     "studyId": {

--- a/registered-json-schemas/PortalDataset.json
+++ b/registered-json-schemas/PortalDataset.json
@@ -29,7 +29,7 @@
       "type": "string"
     },
     "contributor": {
-      "description": "Institution of person repsonsible for collecting and managing data. Properly formatted name of organization(s) or person(s) that contributed to the dataset.",
+      "description": "Institution or person responsible for collecting and managing the files and records in the dataset.",
       "items": {
         "type": "string"
       },

--- a/registered-json-schemas/Superdataset.json
+++ b/registered-json-schemas/Superdataset.json
@@ -18,13 +18,18 @@
       "title": "Alternate Name",
       "type": "string"
     },
+    "citation": {
+      "description": "identifies academic articles that are recommended by the data provider be cited in addition to the dataset itself.",
+      "title": "Citation",
+      "type": "string"
+    },
     "conditionsOfAccess": {
       "description": "Additional requirements a user may need outside of Data Use Modifiers. This could include additional registration, updating profile information, joining a Synapse Team, or using specific authentication methods like 2FA or RAS. Omit property if not applicable/unknown.",
       "title": "User Specific Restriction",
       "type": "string"
     },
     "contributor": {
-      "description": "Properly formatted name of organization(s) or person(s) that contributed to the dataset.",
+      "description": "Institution of person repsonsible for collecting and managing data. Properly formatted name of organization(s) or person(s) that contributed to the dataset.",
       "items": {
         "type": "string"
       },

--- a/registered-json-schemas/Superdataset.json
+++ b/registered-json-schemas/Superdataset.json
@@ -24,7 +24,7 @@
       "type": "string"
     },
     "contributor": {
-      "description": "Organization(s) or person(s) that contributed to the dataset.",
+      "description": "Properly formatted name of organization(s) or person(s) that contributed to the dataset.",
       "items": {
         "type": "string"
       },
@@ -40,12 +40,12 @@
       "type": "array"
     },
     "creator": {
-      "description": "Organization or person that is creator of the dataset. Default is the PI of the project and/or the user who created all files in the dataset.",
+      "description": "Properly formatted name of the organization or person that is creator of the dataset (e.g. \"NF-OSI\" or \"Robert Allaway\"), not an id. Default is the project PI and/or the user who created all files/records.",
       "title": "Creator",
       "type": "string"
     },
     "dataType": {
-      "description": "Reflects the data types of files within the dataset.",
+      "description": "Reflects the data types within the dataset.",
       "items": {
         "description": "What the data (file) contains.",
         "enum": [
@@ -95,7 +95,7 @@
       "type": "array"
     },
     "dataUseModifiers": {
-      "description": "List of data use ontology (DUO) terms that are true for dataset, which describes the allowable scope and terms for data use. Omit property if not applicable/unknown.",
+      "description": "List of data use ontology (DUO) terms that are true for dataset, which describes the allowable scope and terms for data use. Most datasets allow \"General Research Use\" unless otherwise specified.",
       "items": {
         "description": "",
         "enum": [
@@ -183,6 +183,11 @@
       ],
       "type": "string"
     },
+    "individualCount": {
+      "description": "Number of unique individuals included in the dataset (whether as individual-level or as aggregate data). Omit if not applicable/unknown.",
+      "title": "Individual Count",
+      "type": "integer"
+    },
     "keywords": {
       "items": {
         "type": "string"
@@ -241,7 +246,7 @@
       "type": "array"
     },
     "measurementTechnique": {
-      "description": "Assay used to generate original data. Omit if not applicable (e.g. for curated dataset such as a list compounds from a database or text extracted from Wikipedia).",
+      "description": "What's used to generate original data, typically referring to the assay. Omit if not applicable (e.g. for curated dataset such as a list compounds from a database or text extracted from Wikipedia).",
       "title": "Measurement Technique",
       "enum": [
         "2D AlamarBlue absorbance",
@@ -466,6 +471,11 @@
       "title": "Species",
       "type": "array"
     },
+    "specimenCount": {
+      "description": "Number of unique specimens included in the dataset. Omit if not applicable/unknown.",
+      "title": "Specimen Count",
+      "type": "integer"
+    },
     "studyId": {
       "description": "Identifier for the study (project) from which the dataset was derived.",
       "title": "Study ID",
@@ -492,7 +502,7 @@
       "type": "array"
     },
     "yearProcessed": {
-      "description": "Year data were processed. Only for processed data type and when data series is \"NF-OSI Processed Data\"; omit if not applicable/unknown.",
+      "description": "Year data were processed. Only for processed dataset type and when data series is \"NF-OSI Processed Data\"; omit if not applicable/unknown.",
       "title": "Year Processed",
       "type": "integer"
     }

--- a/registered-json-schemas/Superdataset.json
+++ b/registered-json-schemas/Superdataset.json
@@ -29,7 +29,7 @@
       "type": "string"
     },
     "contributor": {
-      "description": "Institution of person repsonsible for collecting and managing data. Properly formatted name of organization(s) or person(s) that contributed to the dataset.",
+      "description": "Institution or person responsible for collecting and managing the files and records in the dataset.",
       "items": {
         "type": "string"
       },


### PR DESCRIPTION
The terminology wrangling continues mostly for #471. Already went back and forth internally on this. Originally, we were going to add `individuals` and `specimens` to allow more useful filtering by these parameters. Later Alberto suggested `populationSize` and I initially agreed [here](https://sagebionetworks.jira.com/browse/SWC-7223?focusedCommentId=240578), but then upon further research and thought, I just don't think it's 1) going to be as clear as `individualCount` and `specimenCount` 2) population size already has a specific technical meaning in ecology and statistics (the total natural population) that might cause confusion.