### PR TITLE
Add mappings

### DIFF
--- a/mappings/cBioPortal/cBioPortal.yaml
+++ b/mappings/cBioPortal/cBioPortal.yaml
@@ -66,6 +66,13 @@ mapping:
       attribute_type: PATIENT
       data_type: NUMBER
       required: false
+  - source: Age
+    target:
+      label: AGE
+      description: Age of patient
+      attribute_type: PATIENT
+      data_type: NUMBER
+      required: false
   - source: tumorType
     target:
       label: TUMOR


### PR DESCRIPTION
@ajs3nj FYI, this is an updated mapping file for CTF. It controls the selection of clinical data elements that we will export to cBioPortal. For the already public CTF tables, pretty sure we include everything. However, for the other CTF clinical table that is under AR, we may need to see if more selection/filtering is desired.