### PR TITLE
Register schemas only on release

### DIFF
--- a/.github/workflows/rebuild-artifacts-on-main.yml
+++ b/.github/workflows/rebuild-artifacts-on-main.yml
@@ -78,32 +78,3 @@ jobs:
           repo: nf-osi/dcc-site
           ref: refs/heads/main
           token: ${{ secrets.SERVICE_TOKEN }}
-
-      - name: Register changed JSON schemas with Synapse
-        if: steps.commit_artifacts.outputs.artifacts_changed == 'true'
-        run: |
-          CHANGED=$(git diff --name-only HEAD HEAD~1 registered-json-schemas)
-          if [ -n "$CHANGED" ]; then
-            echo "Changed schemas detected: $CHANGED"
-            # Convert file paths to just filenames for exclusion list
-            ALL_SCHEMAS=$(ls registered-json-schemas/*.json | xargs -n1 basename)
-            CHANGED_SCHEMAS=$(echo "$CHANGED" | xargs -n1 basename)
-            EXCLUDE_LIST=""
-
-            # Build exclude list of schemas that haven't changed
-            for schema in $ALL_SCHEMAS; do
-              if ! echo "$CHANGED_SCHEMAS" | grep -q "$schema"; then
-                EXCLUDE_LIST="$EXCLUDE_LIST $schema"
-              fi
-            done
-
-            if [ -n "$EXCLUDE_LIST" ]; then
-              echo "Registering only changed schemas, excluding: $EXCLUDE_LIST"
-              python utils/register-schemas.py --schema-dir registered-json-schemas --exclude $EXCLUDE_LIST
-            else
-              echo "All schemas changed, registering everything"
-              python utils/register-schemas.py --schema-dir registered-json-schemas
-            fi
-          else
-            echo "No schema files changed, skipping registration"
-          fi

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ We keep the main one, `NF.jsonld`, in the root of the repository, while others a
 
 #### A nice table summarizing what you might want to grab for different purposes
 
-| Artifact | Description | Generated During PRs | Committed to PRs | Updated on Main |
-| -------- | ----------- | :------------------: | :--------------: | :-------------: |
-| `NF.jsonld` | Main output in schematic-compatible JSON-LD format, for distribution and use with schematic and Data Curator. | ✅ (validated) | ❌ | ✅ (auto-committed) |
-| `registered-json-schemas/*.json` | JSON serializations for a subset of the data model, for native functionality with Synapse platform or wherever a JSON definition is preferred. | ✅ (validated) | ❌ | ✅ (auto-committed) |
-| `dist/NF.yaml` | Data model as as a single LinkML-valid YAML file, useful for using LinkML tooling to create Excel spreadsheets. | ✅ (validated) | ❌ | ✅ (auto-committed) |
-| `dist/NF_linkml.jsonld` | JSON-LD from LinkML, best if you want to compare/combine our model with others maintained in LinkML, e.g. see here. There are differences with the `NF.jsonld`. | ✅ (validated) | ❌ | ✅ (auto-committed) |
-| `dist/NF.ttl` | Basically same as above but in Turtle format. | ✅ (validated) | ❌ | ✅ (auto-committed) |
+| Artifact | Description | Generated During PRs | Committed to PRs | Updated on Main | Registered to Synapse |
+| -------- | ----------- | :------------------: | :--------------: | :-------------: | :-------------------: |
+| `NF.jsonld` | Main output in schematic-compatible JSON-LD format, for distribution and use with schematic and Data Curator. | ✅ (validated) | ❌ | ✅ (auto-committed) | N/A |
+| `registered-json-schemas/*.json` | JSON serializations for a subset of the data model, for native functionality with Synapse platform or wherever a JSON definition is preferred. | ✅ (validated) | ❌ | ✅ (auto-committed) | ✅ (only on [release](https://github.com/nf-osi/nf-metadata-dictionary/blob/main/.github/workflows/release-versioned-artifacts.yml)) |
+| `dist/NF.yaml` | Data model as as a single LinkML-valid YAML file, useful for using LinkML tooling to create Excel spreadsheets. | ✅ (validated) | ❌ | ✅ (auto-committed) | N/A |
+| `dist/NF_linkml.jsonld` | JSON-LD from LinkML, best if you want to compare/combine our model with others maintained in LinkML, e.g. see here. There are differences with the `NF.jsonld`. | ✅ (validated) | ❌ | ✅ (auto-committed) | N/A |
+| `dist/NF.ttl` | Basically same as above but in Turtle format. | ✅ (validated) | ❌ | ✅ (auto-committed) | N/A |
 
-**Note:** All artifacts are built and validated during PRs but not committed to avoid merge conflicts. All artifacts are automatically rebuilt and committed to `main` after merge.
+**Note:** All artifacts are built and validated during PRs but not committed to avoid merge conflicts. All artifacts are automatically rebuilt and committed to `main` after merge. **JSON schemas are only registered with Synapse during versioned releases** (see [release workflow](.github/workflows/release-versioned-artifacts.yml)).
 
 In general, .jsonld or .ttl artifacts facilate model querying and comparison if you know how to load them into compatible linked data tooling. 
 


### PR DESCRIPTION
Finalize changes described in #714. Previously, we registered schemas with each update to `main` as "latest". However, a new requirement for Synapse Grid session usage is that JSON schemas are semantically versioned, so we should only register schemas when released with a version. This removes registration appropriately, while registration workflow has been added in #719. 