### PR TITLE
Make compound fields required in PlateBasedReporterAssayTemplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ schema-registration-log.md
 # Misc
 .Rhistory
 .DS_Store
+CLAUDE.md

--- a/modules/props.yaml
+++ b/modules/props.yaml
@@ -205,13 +205,13 @@ slots:
     annotations:
       requiresDependency: compoundDoseUnit
     description: A dose quantity for the treatment compound. To be used with compoundDoseUnit.
-    required: false
+    required: true
   compoundDoseUnit:
     description: A unit associated with the value(s) in compoundDose.
-    required: false
+    required: true
   compoundName:
-    description: Common name for a compound, e.g. “Selumetinib” (https://pubchem.ncbi.nlm.nih.gov/compound/10127622)
-    required: false
+    description: Common name for a compound, e.g. "Selumetinib" (https://pubchem.ncbi.nlm.nih.gov/compound/10127622)
+    required: true
   concentrationMaterial:
     annotations:
       validationRules: num


### PR DESCRIPTION
## Summary

This PR makes three compound-related fields **required** for the `PlateBasedReporterAssayTemplate`:
- `compoundName`
- `compoundDose`
- `compoundDoseUnit`

## Changes

Modified `modules/props.yaml` to set `required: true` for the three compound properties (lines 204-214).

## Rationale

These fields are essential metadata for plate-based reporter assay experiments (2D AlamarBlue, 2D Incucyte, ELISA, sandwich ELISA, etc.). Making them required ensures:
- Complete metadata capture for compound-based experiments
- Data consistency across all plate-based reporter assay submissions
- Better reproducibility by mandating dose and unit information

The existing `requiresDependency` annotation between `compoundDose` and `compoundDoseUnit` is maintained to ensure they are used together.

## Additional Changes

Added `CLAUDE.md` to `.gitignore` to prevent accidental commits of local documentation files.

## Testing

CI will validate that:
- All artifacts build successfully from the updated module sources
- JSON schemas are generated correctly with the new requirements
- Template validation passes