### PR TITLE
Add prism file format and update pzfx description

### DIFF
--- a/modules/Data/FileFormat.yaml
+++ b/modules/Data/FileFormat.yaml
@@ -336,6 +336,11 @@ enums:
         - JavaScript Object Notation
         description: JavaScript Object Notation format; a lightweight, text-based format to represent tree-structured data using key-value pairs.
         meaning: EDAM:format_3464
+      prism:
+        aliases:
+        - GraphPad Prism file
+        description: GraphPad Prism native file format (Prism 10+) for storing data tables, graphs, layouts, and analysis results. Uses an open access format leveraging industry standards.
+        source: https://www.graphpad.com/features
       rds:
         description: R binary data format similar to RData.
         source: https://www.datafiles.samhsa.gov/get-help/format-specific-issues/how-do-i-read-data-r
@@ -463,7 +468,7 @@ enums:
         - Not in EDAM as of April 2024.
         source: https://www.psychopy.org/general/dataOutputs.html
       pzfx:
-        description: A PZFX file is a Prism project created by GraphPad Prism, a scientific application used to analyze and graph data. It contains project data including graphs and layouts, notes, and tables.
+        description: Legacy GraphPad Prism XML file format (Prism 5-9) for storing project data including graphs, layouts, notes, and tables. Superseded by the .prism format in Prism 10+.
         source: https://fileinfo.com/extension/pzfx
       rmd:
         description: Markdown document specific to R analyses.


### PR DESCRIPTION
## Summary
Added the new  file format and updated the legacy  format description.

### Changes
**DataFileFormatEnum:**
- Added **prism** - GraphPad Prism native file format (Prism 10+) for storing data tables, graphs, layouts, and analysis results

**OtherFileFormatEnum:**
- Updated **pzfx** description to clarify it is the legacy GraphPad Prism XML file format (Prism 5-9) that has been superseded by the .prism format

### Background
GraphPad Prism introduced a new native file format (.prism) starting with Prism 10, while maintaining backward compatibility with the older XML-based format (.pzfx) from Prism 5-9.

## Test plan
- [ ] Build artifacts with `make all`
- [ ] Verify both prism and pzfx appear in generated schemas
- [ ] Test schema validation passes
