### PR TITLE
Add institutions with ROR IDs to resolve sync issues

### DIFF
--- a/modules/Other/Organization.yaml
+++ b/modules/Other/Organization.yaml
@@ -67,6 +67,10 @@ enums:
         meaning: ''
       Children's National:
         source: https://ror.org/03wa2q724
+      Children's of Alabama:
+        source: https://ror.org/053bp9m60
+      Children's Research Institute:
+        meaning: ''
       Children's Tumor Foundation:
         source: https://ror.org/01hx92781
       Cincinnati Children's Hospital Medical Center:
@@ -195,6 +199,8 @@ enums:
         meaning: ''
       Louisiana Tech University:
         meaning: ''
+      Lurie Children's Hospital:
+        source: https://ror.org/03a6zw892
       Loyola University, Chicago:
         meaning: ''
       L’Inserm dans Paris et l’Île-de-France Centre Nord:
@@ -242,7 +248,7 @@ enums:
       National Institutes of Health:
         meaning: ''
       Nemours Children's Clinic:
-        meaning: https://ror.org/01mzw6m29
+        source: https://ror.org/01mzw6m29
       New Jersey Institute of Technology:
         meaning: ''
       New Mexico State University:
@@ -438,8 +444,10 @@ enums:
         meaning: ''
       University of Colorado Boulder:
         meaning: ''
+      University of Colorado Denver:
+        source: https://ror.org/02hh7en24
       University of Colorado Denver and Anschutz Medical Campus:
-        meaning: ''
+        source: https://ror.org/03wmf1y16
       University of Connecticut:
         meaning: ''
       University of Dayton:


### PR DESCRIPTION
- Add Lurie Children's Hospital (ROR: 03a6zw892)
- Add Children's of Alabama (ROR: 053bp9m60)
- Add Children's Research Institute (no separate ROR, part of Children's National)
- Add University of Colorado Denver (ROR: 02hh7en24)
- Add ROR to University of Colorado Denver and Anschutz Medical Campus (ROR: 03wmf1y16)
- Fix Nemours Children's Clinic ROR field (move from meaning to source)

Resolves #807