### PR TITLE
Fix GitHub Pages deployment

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -32,9 +32,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build using docker
-        if: github.event.action != 'closed'  
+        if: github.event.action != 'closed'
         run: |
-          docker run -v $(pwd):/app ghcr.io/nf-osi/data-model-docs    
+          docker build -t data-model-docs ./docs
+          docker run -v $(pwd):/app data-model-docs    
       
       - name: Deploy preview for PRs
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- Fix broken docs deployment workflow that has been failing since June 2025
- Build Docker image from local `docs/Dockerfile` instead of pulling non-existent image

## Problem
The documentation site at https://nf-osi.github.io/nf-metadata-dictionary/ hasn't been updated since April 1, 2025 because the `publish-docs.yml` workflow has been failing on every push to main since June 2025.

**Root cause:** The workflow tries to pull `ghcr.io/nf-osi/data-model-docs` Docker image, but the `nf-osi/data-model-docs` repository doesn't exist (likely deleted or renamed).

## Solution
Build the Docker image locally from `docs/Dockerfile` instead of pulling from a registry.

**Changes:**
```diff
- docker run -v $(pwd):/app ghcr.io/nf-osi/data-model-docs
+ docker build -t data-model-docs ./docs
+ docker run -v $(pwd):/app data-model-docs
```

## Test Plan
- [ ] Verify workflow runs successfully on this PR
- [ ] Verify docs are generated correctly
- [ ] After merge, confirm site updates at https://nf-osi.github.io/nf-metadata-dictionary/

🤖 Generated with [Claude Code](https://claude.com/claude-code)