### PR TITLE
Add Zeiss Apotome 3 to microscopy imaging platforms

### DIFF
--- a/modules/Assay/Platform.yaml
+++ b/modules/Assay/Platform.yaml
@@ -194,6 +194,9 @@ enums:
       Zeiss LSM 980:
         description: A Zeiss Confocal Microscope
         source: https://pages.zeiss.com/rs/896-XMS-794/images/ZEISS-Microscopy_Product-Brochure_ZEISS-LSM-980.pdf
+      Zeiss Apotome 3:
+        description: A structured illumination module that adds optical sectioning capabilities to standard ZEISS widefield fluorescence microscopes, producing crisp, high-contrast 3D images without the cost and complexity of a confocal system.
+        source: https://www.zeiss.com/microscopy/us/products/light-microscopes/widefield-microscopes/apotome-3.html
   MRIPlatformEnum:
     description: Magnetic Resonance Imaging (MRI) platforms
     title: MRI Platform


### PR DESCRIPTION
## Summary

- Added **Zeiss Apotome 3** as a new permissible value in `MicroscopyImagingPlatformEnum`
- This is a structured illumination module that adds optical sectioning capabilities to standard ZEISS widefield fluorescence microscopes, producing crisp, high-contrast 3D images without the cost and complexity of a confocal system
- Includes description and official ZEISS product documentation link

## Test plan

- [ ] Verify `modules/Assay/Platform.yaml` has the new entry under `MicroscopyImagingPlatformEnum`
- [ ] Confirm CI pipeline builds all artifacts successfully
- [ ] Validate JSON schemas are generated without errors
- [ ] Check that the new platform value appears in generated artifacts