### PR TITLE
Add spatial transcriptomics template (#160)

### DIFF
--- a/modules/Assay/Assay.yaml
+++ b/modules/Assay/Assay.yaml
@@ -292,6 +292,9 @@ enums:
         notes:
         - Note that term has no matches in OLS as of June 2022.
         source: https://doi.org/10.3390/photonics8050162
+      spatial transcriptomics:
+        description: Assay that allows visualization and quantitative analysis of the transcriptome with spatial resolution in individual tissue sections.
+        meaning: EFO:0008994
       traction force microscopy:
         description: An experimental method for determining the tractions on the surface of a biological cell by obtaining measurements of the surrounding displacement field within an in vitro extracellular matrix (ECM)
         source: https://en.wikipedia.org/wiki/Traction_force_microscopy

--- a/modules/Assay/Platform.yaml
+++ b/modules/Assay/Platform.yaml
@@ -68,6 +68,9 @@ enums:
       Chromium X:
         description: (From 10x Genomics) Single-cell platform that can analyze hundreds to hundreds of thousands of cells in single run for e.g. gene expression, chromatin accessibility, cell surface proteins, immune clonotype, antigen specificity, CRISPR perturbation screens).
         source: https://www.10xgenomics.com/chromium-x
+      10X Visium CytAssist:
+        description: 10x Genomics CytAssist instrument that enables spatial gene expression profiling from standard histology tissue sections by transferring RNA to a Visium capture slide.
+        source: https://www.10xgenomics.com/products/visium-cytassist-spatial-gene-expression
   ArrayPlatformEnum:
     description: Array-based platforms for genomic and transcriptomic measurements
     title: Array Platform

--- a/modules/Template/Data_SpatialTranscriptomics.yaml
+++ b/modules/Template/Data_SpatialTranscriptomics.yaml
@@ -1,0 +1,41 @@
+classes:
+  SpatialTranscriptomicsTemplate:
+    annotations:
+      required: false
+      requiresComponent: ''
+      templateUsage: most_common
+      templateFor:
+        dataType:
+        - gene expression
+        assay:
+        - spatial transcriptomics
+      dataGranularity: specimen-level
+    close_mappings:
+    - htan:VisiumSpatialTranscriptomicsLevel1
+    description: Template for describing raw data from spatial transcriptomics experiments,
+      including sequencing-based approaches (e.g. 10x Visium, 10x Visium CytAssist)
+      and in-situ hybridization-based approaches (e.g. NanoString CosMx, GeoMx).
+    is_a: GeneticsAssayTemplate
+    slots:
+    - captureArea
+    - visiumslideID
+    - cytassistSample
+    - probeSet
+    - libraryPrep
+    - libraryPreparationMethod
+    - specimenType
+    slot_usage:
+      assay:
+        range: SequencingAssayEnum
+        ifabsent: string(spatial transcriptomics)
+      platform:
+        any_of:
+        - range: SequencingPlatformEnum
+        - range: ArrayPlatformEnum
+        - range: ImagingSystemPlatformEnum
+      fileFormat:
+        any_of:
+        - range: SequencingFileFormatEnum
+        - range: ImagingFileFormatEnum
+      dataType:
+        ifabsent: string(gene expression)

--- a/modules/Template/Data_SpatialTranscriptomics.yaml
+++ b/modules/Template/Data_SpatialTranscriptomics.yaml
@@ -31,7 +31,6 @@ classes:
       platform:
         any_of:
         - range: SequencingPlatformEnum
-        - range: ImagingSystemPlatformEnum
       fileFormat:
         range: SequencingFileFormatEnum
       dataType:

--- a/modules/Template/Data_SpatialTranscriptomics.yaml
+++ b/modules/Template/Data_SpatialTranscriptomics.yaml
@@ -1,5 +1,5 @@
 classes:
-  SpatialTranscriptomicsTemplate:
+  SpatialTranscriptomicsSequencingTemplate:
     annotations:
       required: false
       requiresComponent: ''
@@ -12,9 +12,9 @@ classes:
       dataGranularity: specimen-level
     close_mappings:
     - htan:VisiumSpatialTranscriptomicsLevel1
-    description: Template for describing raw data from spatial transcriptomics experiments,
-      including sequencing-based approaches (e.g. 10x Visium, 10x Visium CytAssist)
-      and in-situ hybridization-based approaches (e.g. NanoString CosMx, GeoMx).
+    description: Template for describing sequencing-based and expression data files from
+      spatial transcriptomics experiments (e.g., FASTQ files and count matrices from 10x
+      Visium, 10x Visium CytAssist, NanoString CosMx, GeoMx).
     is_a: GeneticsAssayTemplate
     slots:
     - captureArea
@@ -34,8 +34,40 @@ classes:
         - range: ArrayPlatformEnum
         - range: ImagingSystemPlatformEnum
       fileFormat:
-        any_of:
-        - range: SequencingFileFormatEnum
-        - range: ImagingFileFormatEnum
+        range: SequencingFileFormatEnum
       dataType:
         ifabsent: string(gene expression)
+
+  SpatialTranscriptomicsImagingTemplate:
+    annotations:
+      required: false
+      requiresComponent: ''
+      templateUsage: most_common
+      templateFor:
+        dataType:
+        - image
+        assay:
+        - spatial transcriptomics
+      dataGranularity: specimen-level
+    description: Template for describing imaging data files from spatial transcriptomics
+      experiments, such as tissue section histology or fluorescence images (e.g., from
+      10x Visium, NanoString CosMx, GeoMx).
+    is_a: ImagingAssayTemplate
+    slots:
+    - parentSpecimenID
+    - specimenID
+    - aliquotID
+    - captureArea
+    - visiumslideID
+    - cytassistSample
+    - specimenType
+    slot_usage:
+      assay:
+        range: ImagingAssayEnum
+        ifabsent: string(spatial transcriptomics)
+      platform:
+        range: ImagingSystemPlatformEnum
+      fileFormat:
+        range: ImagingFileFormatEnum
+      dataType:
+        ifabsent: string(image)

--- a/modules/Template/Data_SpatialTranscriptomics.yaml
+++ b/modules/Template/Data_SpatialTranscriptomics.yaml
@@ -31,7 +31,6 @@ classes:
       platform:
         any_of:
         - range: SequencingPlatformEnum
-        - range: ArrayPlatformEnum
         - range: ImagingSystemPlatformEnum
       fileFormat:
         range: SequencingFileFormatEnum

--- a/modules/props.yaml
+++ b/modules/props.yaml
@@ -338,6 +338,13 @@ slots:
     title: Current Version
     required: false
     see_also: https://www.w3.org/TR/vocab-dcat-3/#Property:resource_version
+  cytassistSample:
+    description: Whether the 10x Genomics CytAssist instrument was used for sample preparation in the spatial transcriptomics experiment.
+    enum_range:
+    - 'True'
+    - 'False'
+    title: CytAssist Sample
+    required: false
   dataCollectionMode:
     description: Mode of data collection in tandem MS assays. Either DDA (data-dependent acquisition) or DIA (data-independent) acquisition.
     enum_range:
@@ -1131,6 +1138,11 @@ slots:
     - range: DrugScreenAssayEnum
     required: false
     title: Protocol assay
+  probeSet:
+    description: Identifier or name of the probe set used in the spatial transcriptomics experiment (e.g., Visium Human Transcriptome Probe Set v2.0).
+    range: string
+    title: Probe Set
+    required: false
   protocolPurpose:
     description: Brief description of the protocol purpose.
     in_subset:
@@ -1479,6 +1491,11 @@ slots:
     range: LateralManifestationEnum
     required: false
     title: Vestibular schwannoma
+  visiumslideID:
+    description: Unique identifier for the Visium slide used in the spatial transcriptomics experiment. Slide serial numbers begin with V1, V4, V5, or H1 (e.g., V10J25-015).
+    range: string
+    title: Visium Slide ID
+    required: false
   vitalStatus:
     description: Vital status of the patient.
     range: VitalStatusEnum


### PR DESCRIPTION
## Summary
- Adds `SpatialTranscriptomicsTemplate` in `modules/Template/Data_SpatialTranscriptomics.yaml`, modeled after the `sagedm-spatial` Synapse schema
- Adds three new slots to `props.yaml`: `cytassistSample`, `probeSet`, `visiumslideID`
- Adds `10X Visium CytAssist` to `SequencingPlatformEnum` in `modules/Assay/Platform.yaml`

## Template details
- Inherits from `GeneticsAssayTemplate` (provides specimen, diagnosis, tumorType, specimenPreparationMethod, etc.)
- Assay defaults to `spatial transcriptomics`; dataType defaults to `gene expression`
- Platform accepts any of `SequencingPlatformEnum`, `ArrayPlatformEnum`, or `ImagingSystemPlatformEnum` to cover 10x Visium, CytAssist, NanoString CosMx/GeoMx
- FileFormat accepts sequencing (fastq, bam, etc.) or imaging (tiff, ome-tiff) formats

## Test plan
- [ ] Verify `SpatialTranscriptomicsTemplate` is generated correctly in NF.jsonld
- [ ] Confirm new slots (`cytassistSample`, `probeSet`, `visiumslideID`) appear in the schema
- [ ] Confirm `10X Visium CytAssist` appears as a valid platform value

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)