### PR TITLE
Fix enum-template validation mismatches for Synapse Curator (#831)

### DIFF
--- a/modules/Assay/Assay.yaml
+++ b/modules/Assay/Assay.yaml
@@ -66,6 +66,12 @@ enums:
       miRNA-seq:
         description: Small RNA measurements collected from RNA sequencing experiments
         meaning: OBI:0002112
+      next-generation sequencing:
+        aliases:
+        - NGS
+        - next generation sequencing
+        description: High-throughput DNA sequencing methods that allow massively parallel sequencing of millions of DNA fragments simultaneously.
+        meaning: NCIT:C101294
       next generation targeted sequencing:
         aliases:
         - Targeted NGS
@@ -214,6 +220,17 @@ enums:
         - fMRI
         description: The principle of functional MRI imaging is to take a series of images of an organ in quick succession and to statistically analyze the images for differences among them. Most commonly used in studies of brain function. [  NCI  ]
         meaning: NCIT:C17958
+      gel filtration chromatography:
+        aliases:
+        - gel-permeation chromatography
+        - GPC
+        description: '''Gel filtration chromatography (synonym: gel permeation chromatography - GPC) is a type of size-exclusion chromatography (SEC), that separates analytes on the basis of size, typically in organic solvents.  The technique is often used for the analysis of polymers.''
+
+          '
+        meaning: CHMO:0001011
+      high content screen:
+        description: An image analysis technique combining automated fluorescence microscopy with multi-parameter quantitative image analysis for the large scale study of cells (cellomics).
+        meaning: EFO:0007550
       high frequency ultrasound:
         description: High frequency ultrasound (HFUS) is an imaging modality that can give greater resolution of surface changes in skin (review in PMID:24583666)
       immunocytochemistry:
@@ -368,6 +385,11 @@ enums:
       proximity extension assay:
         description: Olink's Proximity Extension Assay (PEA) combines specificity and scalability to enable high-throughput, multiplex protein biomarker analysis.
         source: https://olink.com/technology/what-is-pea
+      SomaScan:
+        aliases:
+        - SomaLogic SomaScan
+        description: Aptamer-based proteomics assay using SOMAmer reagents (modified DNA aptamers) to quantify thousands of proteins simultaneously from small sample volumes.
+        source: https://somalogic.com/somascan-platform/
       ultra high-performance liquid chromatography/tandem mass spectrometry:
         aliases:
         - U-HPLC/MS/MS
@@ -549,6 +571,9 @@ enums:
       weight:
         description: An assay or measurement that quantifies the mass or weight of a subject, specimen, or sample. Commonly used in clinical assessments, biosample characterization, and longitudinal health monitoring.
         meaning: EFO:0004338
+      survival:
+        description: Any quantitative measurement of survival of or in an individual or study population.
+        meaning: MI:0410
       word recognition score:
         description: Assays how well a person can understand speech by repeating a list of words. The WRS is a percentage of words correctly repeated. It's a more functional measure because it predicts whether hearing loss can be improved with amplification.
   CellBasedAssayEnum:
@@ -774,6 +799,9 @@ enums:
       oxygen consumption assay:
         description: Assay measuring oxygen consumption rate (OCR) to assess changes in metabolism in e.g. cancer cells
         source: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8275291/
+      pattern electroretinogram:
+        description: Pattern electroretinogram (PERG) is an electrophysiologic ophthalmologic test that provides non-invasive objective, quantitative measurement of central retinal function. PERG is the retinal response to a pattern-reversing, black-and-white checkerboard or stripped stimulus. The PERG assesses both macular and retinal ganglion cell electrical activity and can help differentiate between diseases of macular versus optic nerve dysfunction.
+        source: https://www.ncbi.nlm.nih.gov/books/NBK560641
       perineurial cell thickness:
         aliases:
         - 3D-EM

--- a/modules/Template/Data_CellAssays.yaml
+++ b/modules/Template/Data_CellAssays.yaml
@@ -20,7 +20,7 @@ classes:
         - electrochemiluminescence
         - focus forming assay
         - in vivo tumor growth
-        - Matrigel-based tumorigenesis assay
+        - in vitro tumorigenesis
       dataGranularity: specimen-level
     description: 'Data that characterizes cell/tissue morphology or physiology often in the context of different experimental conditions'
     is_a: BiologicalAssayDataTemplate
@@ -179,7 +179,6 @@ classes:
         assay:
         - 2D AlamarBlue absorbance
         - 2D AlamarBlue fluorescence
-        - 2D Incucyte
         - cell viability assay
         - combination library screen
         - combination screen


### PR DESCRIPTION
## Summary
Fixes validation failures discovered during the Synapse Curator majority rollout where `templateFor.assay` values were missing from the enum range assigned in each template's `slot_usage.assay`. When Synapse validates data against a template, it rejects assay values not in the template's enum — causing failures for existing valid data.

**Enum additions (`modules/Assay/Assay.yaml`)**
- `ImagingAssayEnum`: added `gel filtration chromatography` and `high content screen` (both were only in `CellBasedAssayEnum` but referenced by `ImagingAssayTemplate`)
- `SequencingAssayEnum`: added `next-generation sequencing` (referenced by `BulkSequencingAssayTemplate`, `ScSequencingAssayTemplate`, and others but absent from the enum)
- `MassSpectrometryAssayEnum`: added `SomaScan` (referenced by `AffinityProteomicsTemplate` but absent from the enum)
- `ClinicalBehavioralAssayEnum`: added `survival` (referenced by `ClinicalAssayTemplate` but was only in `CellBasedAssayEnum`)
- `CellBasedAssayEnum`: added `pattern electroretinogram` (referenced by `ElectrophysiologyAssayTemplate` but was only in `ClinicalBehavioralAssayEnum`)

**Template fixes (`modules/Template/Data_CellAssays.yaml`)**
- `CellTissuePhenotypingTemplate`: replaced alias `Matrigel-based tumorigenesis assay` in `templateFor.assay` with the canonical enum value `in vitro tumorigenesis`
- `PlateBasedReporterAssayTemplate`: removed `2D Incucyte` from `templateFor.assay` — it is a platform (in `OtherPlatformEnum`), not an assay value

## Test plan
- [ ] Verify NF.jsonld builds cleanly with no enum errors
- [ ] Confirm the 5 new assay enum values are visible in Synapse Curator dropdowns for the relevant templates
- [ ] Spot-check existing NF Portal data with `assay=high content screen`, `assay=survival`, `assay=pattern electroretinogram` etc. now passes validation

Closes #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)