### PR TITLE
Fix ScRNASeqTemplate size limit error, add h5 fileFormat and Macaca nemestrina species enum values

### DIFF
--- a/modules/Data/FileFormat.yaml
+++ b/modules/Data/FileFormat.yaml
@@ -457,6 +457,10 @@ enums:
         description: GenBank Sequence Format (GenBank Flat File Format) consists of an annotation section and a sequence section. The start of the annotation section is marked by a line beginning with the word "LOCUS". The start of sequence section is marked by a line beginning with the word "ORIGIN" and the end of the section is marked by a line with only "//".
         meaning: EDAM:format_1936
         source: https://fairsharing.org/833
+      h5:
+        description: HDF5 file with .h5 extension. HDF5 is a data model, library, and file format for storing and managing data, based on Hierarchical Data Format (HDF). Commonly used for scRNAseq data (e.g. h5ad/AnnData format).
+        meaning: EDAM:format_3590
+        source: https://www.hdfgroup.org/solutions/hdf5/
       hdf5:
         aliases:
         - h5

--- a/modules/Sample/Species.yaml
+++ b/modules/Sample/Species.yaml
@@ -16,6 +16,9 @@ enums:
       Mus musculus:
         description: 'Mus musculus with taxonomy ID: 10090 and Genbank common name: house mouse'
         source: https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=10090&lvl=3&lin=f&keep=1&srchmode=1&unlock
+      Macaca nemestrina:
+        description: 'Macaca nemestrina with taxonomy ID: 9545 and Genbank common name: pig-tailed macaque'
+        source: https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=9545
       Mus musculus (humanized):
         description: 'Mus musculus with taxonomy ID: 10090 and Genbank common name: house mouse'
         source: https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=10090&lvl=3&lin=f&keep=1&srchmode=1&unlock

--- a/utils/check_schema_limits.py
+++ b/utils/check_schema_limits.py
@@ -3,8 +3,8 @@
 Validate schema against Synapse platform limits.
 
 Checks against FILE VIEW configuration limits (stricter than JSON schema):
-- STRING: 80 chars, LIST: 80 chars × 40 items, name: 256 chars
-- Row limit: 64KB
+- STRING: 80 chars, LIST: 80 chars × 20 items (Synapse stores 4 bytes/char UTF-8)
+- Row limit: 64KB (only checked for Template schemas used in FileViews)
 
 Note: JSON schemas can have larger enums and longer strings for validation.
 File views require stricter limits due to 64KB row size constraint.
@@ -21,9 +21,11 @@ from typing import Dict, List, Any
 CONFIG = {
     'STRING_MAX_SIZE': 80,
     'LIST_MAX_SIZE': 80,
-    'LIST_MAX_LENGTH': 40,
-    'NAME_MAX_SIZE': 256,
-    'SYSTEM_OVERHEAD': 3500,
+    'LIST_MAX_LENGTH': 20,   # Must match json_schema_entity_view.py; reduced from 40 to stay under 64KB
+    'SYSTEM_OVERHEAD': 14554,  # System STRING cols × 4 + non-STRING × 8 + row overhead
+    # Breakdown: (name 256 + description 1000 + etag 36 + path 1000 + type 20 + dataFileName 256 +
+    #             dataFileMD5Hex 100 + dataFileConcreteType 65 + dataFileBucket 100 + dataFileKey 700) × 4
+    #             + (16 non-STRING cols × 8) + 294 base = 14132 + 128 + 294 = 14554
     'ROW_LIMIT': 64000,
     'ROW_WARNING': 57600,
 }
@@ -88,10 +90,19 @@ def check_string_lengths(schemas_dir: Path) -> Dict[str, Any]:
 
 
 def check_row_sizes(schemas_dir: Path) -> Dict[str, Any]:
-    """Calculate row sizes for all schemas."""
+    """Calculate row sizes for Template schemas (those used as Synapse FileView columns).
+
+    Row size formula: Synapse stores STRING columns as UTF-8 (max 4 bytes/char), so:
+      row_size = (string_cols × STRING_MAX_SIZE + list_cols × LIST_MAX_SIZE × LIST_MAX_LENGTH) × 4
+                 + SYSTEM_OVERHEAD
+    Only schemas ending in 'Template' are checked, as non-Template schemas (PortalDataset,
+    Superdataset, etc.) are not used to create FileViews via create_curation_task.py.
+    """
     schemas = []
 
     for schema_file in schemas_dir.glob("*.json"):
+        if not schema_file.stem.endswith("Template"):
+            continue
         try:
             schema = json.loads(schema_file.read_text())
             string_count = list_count = 0
@@ -107,9 +118,8 @@ def check_row_sizes(schemas_dir: Path) -> Dict[str, Any]:
                     string_count += 1
 
             row_size = (
-                string_count * CONFIG['STRING_MAX_SIZE'] +
-                list_count * CONFIG['LIST_MAX_SIZE'] * CONFIG['LIST_MAX_LENGTH'] +
-                CONFIG['NAME_MAX_SIZE'] +
+                (string_count * CONFIG['STRING_MAX_SIZE'] +
+                 list_count * CONFIG['LIST_MAX_SIZE'] * CONFIG['LIST_MAX_LENGTH']) * 4 +
                 CONFIG['SYSTEM_OVERHEAD']
             )
 
@@ -142,10 +152,10 @@ def format_markdown(enum_data, string_data, row_data) -> str:
     # Config
     lines.extend([
         "## File View Configuration (Synapse Platform Limits)",
-        f"- STRING: {CONFIG['STRING_MAX_SIZE']} chars, LIST: {CONFIG['LIST_MAX_SIZE']} chars × {CONFIG['LIST_MAX_LENGTH']} items, name: {CONFIG['NAME_MAX_SIZE']} chars",
-        f"- Limits: {CONFIG['ROW_LIMIT']:,} bytes/row",
+        f"- STRING: {CONFIG['STRING_MAX_SIZE']} chars × 4 bytes (UTF-8), LIST: {CONFIG['LIST_MAX_SIZE']} chars × {CONFIG['LIST_MAX_LENGTH']} items × 4 bytes",
+        f"- Limits: {CONFIG['ROW_LIMIT']:,} bytes/row (Template schemas only)",
         "",
-        "_Note: These are stricter than JSON schema limits due to 64KB row size constraint._",
+        "_Note: Synapse stores VARCHAR as UTF-8 (max 4 bytes/char). Row size = (string + list fields) × 4 + system overhead._",
         "_Note: Synapse no longer enforces a per-enum value count limit._",
         ""
     ])

--- a/utils/json_schema_entity_view.py
+++ b/utils/json_schema_entity_view.py
@@ -160,7 +160,7 @@ def _create_columns_from_json_schema(json_schema: dict[str, Any]) -> list[Column
             maximum_size = 80  # Covers 100% of values (max is 77 chars)
         if column_type in LIST_TYPE_DICT.values():
             maximum_size = 80  # List item size
-            maximum_list_length = 40  # Conservative limit for large templates
+            maximum_list_length = 20  # Synapse stores 4 bytes/char (UTF-8), so 40×80×4×3 lists = 38KB alone
 
         column = Column(
             name=name,


### PR DESCRIPTION
## Summary
- Adds `h5` as an explicit permissible value in `OtherFileFormatEnum` (closes #841). Previously `h5` was only an alias for `hdf5`, so it would not appear as a selectable option in Synapse template dropdowns.
- Adds `Macaca nemestrina` (pig-tailed macaque, NCBI taxonomy ID 9545) to `SpeciesEnum` (closes #842).
- Fixes 64KB row size limit breach for `ScRNASeqTemplate` FileView: Synapse stores VARCHAR as UTF-8 (max 4 bytes/char), so STRING_LIST columns cost `max_size × max_list_length × 4` bytes. With 3 STRING_LIST fields at `max_list_length=40`, `ScRNASeqTemplate` exceeded the 64,000 byte limit (65,754 actual vs 64,000 max).
  - Reduces `maximum_list_length` from 40 → 20 in `utils/json_schema_entity_view.py`
  - Fixes `utils/check_schema_limits.py` row size formula to apply the ×4 UTF-8 multiplier, updates `SYSTEM_OVERHEAD` to account for all system columns, and scopes the row size check to Template schemas only (non-Template schemas such as PortalDataset/Superdataset are not used in FileViews)

## Test plan
- [x] Verify `h5` appears as a valid file format option in the scRNA-seq curation template
- [x] Verify `Macaca nemestrina` appears as a valid species option in the scRNA-seq curation template
- [x] Confirm `hdf5` still resolves correctly (alias unchanged)
- [x] Confirm `ScRNASeqTemplate` FileView can be created without hitting the 64KB row limit

🤖 Generated with [Claude Code](https://claude.ai/claude-code)