### PR TITLE
Add MGIEasy FS PCR-Free DNA Library Prep Set to libraryPreparationMethod

### DIFF
--- a/modules/Assay/Parameter.yaml
+++ b/modules/Assay/Parameter.yaml
@@ -110,6 +110,9 @@ enums:
       KAPA mRNA HyperPrep Kit:
         description: The KAPA mRNA HyperPrep Kit is a highly efficient library preparation kit designed for generating stranded RNA-seq libraries with low input amounts and reduced bias.
         source: https://sequencing.roche.com/global/en/products/group/kapa-rna-hyperprep-kits.html
+      MGIEasy FS PCR-Free DNA Library Prep Set:
+        description: MGI Tech PCR-free library preparation kit for DNA sequencing
+        source: https://global-mgitech.com/library-preparation-kits/mgieasy-fs-pcr-free-dna-library-prep-set/
       NEBNext mRNA Library Prep Reagent Set for Illumina:
         description: NEBNext mRNA Library Prep Reagent Set for Illumina
         source: https://www.neb.com/products/e6100-nebnext-mrna-library-prep-reagent-set-for-illumina


### PR DESCRIPTION
## Summary
- Adds MGIEasy FS PCR-Free DNA Library Prep Set as a permissible value to `LibraryPreparationMethodEnum`
- Includes product description and vendor source URL

## Changes
- Modified `modules/Assay/Parameter.yaml` to add new library preparation method enum value
- Entry placed after KAPA products to maintain vendor grouping pattern

## References
- Resolves #845
- Product page: https://global-mgitech.com/library-preparation-kits/mgieasy-fs-pcr-free-dna-library-prep-set/

## Test plan
- [x] YAML syntax is valid
- [x] CI/CD pipeline builds all artifacts successfully
- [x] CI/CD validates JSON schemas against Synapse API
- [ ] New value appears in `BulkSequencingAssayDataTemplate` and `ScSequencingAssayDataTemplate` schemas
