### PR TITLE
Add Leica DMI 6000B microscope to MicroscopyImagingPlatformEnum

### DIFF
--- a/modules/Assay/Platform.yaml
+++ b/modules/Assay/Platform.yaml
@@ -170,6 +170,9 @@ enums:
       Leica Aperio AT2:
         description: (From vendor) The Aperio AT2 is the most compact, highest capacity, brightfield Digital Pathology scanner available.
         source: https://www.leicabiosystems.com/sites/default/files/2020-10/Aperio_AT2_Brochure_USA.pdf
+      Leica DMI 6000B:
+        description: (From vendor) The Leica DMI6000 B is an automated inverted microscope for fluorescence, live cell imaging, and multi-dimensional experiments. It features motorized components for z-drive, objective nosepiece, and fluorescence filter turret.
+        source: https://www.leica-microsystems.com/products/light-microscopes/p/leica-dmi6000-b/
       Leica MZ16: null
       Leica S9 Stereomicroscope:
         description: ''


### PR DESCRIPTION
## Summary

- Adds `Leica DMI 6000B` as a new permissible value in `MicroscopyImagingPlatformEnum` in `modules/Assay/Platform.yaml`
- Inserted alphabetically between `Leica Aperio AT2` and `Leica MZ16`
- Includes vendor description and source URL per existing enum conventions
- No `meaning` (ontology URI) added — consistent with other Leica entries in this enum that lack OBI/NCIT mappings

## Vendor Reference

https://www.leica-microsystems.com/products/light-microscopes/p/leica-dmi6000-b/

## Test plan

- [x] `python utils/gen-json-schema-class.py --skip-validation` completes without errors (63 schemas generated)
- [ ] CI artifact build passes
- [ ] CI dry-run schema validation against Synapse passes