### PR TITLE
Constrain model* attributes to PdxGenomicsAssayTemplate

### DIFF
--- a/modules/Template/Data_Base.yaml
+++ b/modules/Template/Data_Base.yaml
@@ -27,9 +27,9 @@ classes:
     description: 'A template defining basic metadata on deposited data artifacts (i.e.
       files) from experimental assays involving biosamples. Donor/individual attributes
       (species, sex, age, diagnosis) describe the original donor (e.g., human patient
-      tumor). For cell lines, individualID references syn51730943. Model attributes
-      (modelSpecies, modelSex, modelAge) describe any animal model host used. antibodyID
-      and geneticReagentID reference treatments/reagents.'
+      tumor). For cell lines, individualID references syn51730943. antibodyID
+      and geneticReagentID reference treatments/reagents. For PDX data, use
+      PdxGenomicsAssayTemplate which includes model* attributes.'
     is_a: FileBasedTemplate
     slots:
     - dataType
@@ -44,11 +44,6 @@ classes:
     - nf1Genotype
     - nf2Genotype
     - tumorType
-    - modelSystemName
-    - modelSpecies
-    - modelSex
-    - modelAge
-    - modelAgeUnit
     - organ
     - antibodyID
     - geneticReagentID

--- a/modules/Template/Data_Genomics.yaml
+++ b/modules/Template/Data_Genomics.yaml
@@ -195,6 +195,10 @@ classes:
     - transplantationRecipientSpecies
     - transplantationRecipientTissue
     - modelSystemName
+    - modelSpecies
+    - modelSex
+    - modelAge
+    - modelAgeUnit
     - experimentalCondition
     - experimentalTimepoint
     - timepointUnit


### PR DESCRIPTION
Closes #872

## Summary
- Remove `modelSystemName`, `modelSpecies`, `modelSex`, `modelAge`, `modelAgeUnit` from `BiologicalAssayDataTemplate` so they no longer appear in all data templates
- Add `modelSpecies`, `modelSex`, `modelAge`, `modelAgeUnit` explicitly to `PdxGenomicsAssayTemplate` (which already had `modelSystemName`)
- Templates that explicitly declare `modelSystemName` (`BehavioralAssayTemplate`, `CellTissuePhenotypingTemplate`) are unaffected

## Test plan
- [x] Verify `PdxGenomicsAssayTemplate` JSON schema includes all `model*` fields
- [x] Verify other data templates (e.g. `RNASeqTemplate`) no longer include `model*` fields
- [x] Verify `BehavioralAssayTemplate` and `CellTissuePhenotypingTemplate` still include `modelSystemName`

🤖 Generated with [Claude Code](https://claude.com/claude-code)