### PR TITLE
Add shRNA-seq to SequencingAssayEnum

### DIFF
--- a/modules/Assay/Assay.yaml
+++ b/modules/Assay/Assay.yaml
@@ -88,6 +88,11 @@ enums:
       scCGI-seq:
         description: A method for genome-wide CpG island (CGI) methylation sequencing for single cells (scCGI-seq), combining methylation-sensitive restriction enzyme digestion and multiple displacement amplification for selective detection of methylated CGIs
         source: https://www.ncbi.nlm.nih.gov/pubmed/28126923
+      shRNA-seq:
+        aliases:
+        - shRNA library screen sequencing
+        description: A sequencing-based functional genomics assay in which a pooled short hairpin RNA (shRNA) library is introduced into cells, and the relative abundance of individual shRNA constructs is quantified by amplicon sequencing to identify genes affecting a phenotype of interest.
+        meaning: EFO:0030034
       single cell ATAC-seq:
         aliases:
         - scATAC-Seq


### PR DESCRIPTION
## Summary

- Adds `shRNA-seq` (EFO:0030034) to `SequencingAssayEnum` in `modules/Assay/Assay.yaml`
- Includes alias `shRNA library screen sequencing` and a description of the method
- Term was needed to annotate the dataset in nf-osi/nadia#35 (ArrayExpress E-MTAB-8398, Synapse syn74280931), an shRNA library screen using amplicon sequencing

## Test plan

- [ ] Confirm `shRNA-seq` appears correctly in built artifacts after CI runs
- [ ] Verify EFO:0030034 resolves to the correct ontology term

🤖 Generated with [Claude Code](https://claude.com/claude-code)