### PR TITLE
feat: conditional organ requirement based on specimenType

### DIFF
--- a/modules/Template/Data_Genomics.yaml
+++ b/modules/Template/Data_Genomics.yaml
@@ -71,6 +71,22 @@ classes:
     - readDepth
     - targetDepth
     - batchID
+    rules:
+    - description: Organ is required when specimenType is a tissue (not an organism substance like saliva)
+      preconditions:
+        slot_conditions:
+          specimenType:
+            value_presence: PRESENT
+            none_of:
+              - equals_string: mucus
+              - equals_string: saliva
+              - equals_string: stool
+              - equals_string: sweat
+              - equals_string: urine
+      postconditions:
+        slot_conditions:
+          organ:
+            value_presence: PRESENT
 
   GenomicsArrayTemplate:
     annotations:


### PR DESCRIPTION
## Summary
- Adds a conditional rule to `BulkSequencingAssayTemplate`: `organ` is required when `specimenType` is a tissue type, but **not** when it is an organism substance (saliva, mucus, stool, sweat, urine)
- Resolves invalid annotation flags for WGS studies with saliva specimens (e.g. syn62864726)
- Rule is inherited by all child templates: WGSTemplate, RNASeqTemplate, WESTemplate, ScRNASeqTemplate, etc.

The generated JSON schema produces an `if/then` block:
- **if** `specimenType` is present AND not in `[mucus, saliva, stool, sweat, urine]`
- **then** `organ` is required

Closes #881
Closes #882

## Test plan
- [x] CI builds merged YAML and generates JSON schemas successfully
- [x] WGSTemplate JSON schema contains the new conditional `if/then` block in `allOf`
- [x] Sibling templates (RNASeqTemplate, WESTemplate) also inherit the rule
- [x] Synapse dry-run validation passes for affected schemas
- [x] Verify: saliva specimen without `organ` passes validation
- [x] Verify: tissue specimen without `organ` fails validation