### PR TITLE
feat: update accessType vocabulary

### DIFF
--- a/modules/DCC/Portal.yaml
+++ b/modules/DCC/Portal.yaml
@@ -10,8 +10,8 @@ enums:
         description: 'Access is restricted and only available after fulfilling specific requirements, such as submitting a research statement or getting approval directly from the data owner through Synapse. Note that for datasets, if any component file is under controlled access, the entire dataset is considered to be under controlled access.'
       Open Access:
         description: Access without any additional steps/requirements without even needing to be logged in to Synapse account.
-      Private Access:
-        description: Not accessible outside the project admins and study team -- check whether you are on an access team or contact the PI/admin of access team to request access.
+      Private:
+        description: Not accessible to general Synapse users; restricted to specific lab/collaborator members.
       Public Access:
         description: Access without any additional steps/requirements as long as you are logged in to Synapse.
     title: Access type


### PR DESCRIPTION
## Summary

- Renames `Private Access` → `Private` in `AccessTypeEnum` to align with the standardized four-tier vocabulary from #878
- Updates description to match the Synapse ACL/AR signal definition
- The other three values (`Open Access`, `Public Access`, `Controlled Access`) already matched — no changes needed

The final vocabulary:
| Value | Synapse signal |
|---|---|
| `Open Access` | `PUBLIC_GROUP` has DOWNLOAD, no AR |
| `Public Access` | `ALL_REGISTERED` has DOWNLOAD, no AR |
| `Controlled Access` | `ALL_REGISTERED` has READ + AR or legacy access team |
| `Private` | `ALL_REGISTERED` has no access or no request mechanism |

## Test plan

- [ ] CI builds artifacts successfully from updated source
- [ ] Generated JSON schema shows `Private` (not `Private Access`) in the `accessType` enum
- [ ] Vocabulary matches what https://github.com/nf-osi/jobs/pull/156 will write

Closes #878