### PR TITLE
feat: vocabulary updates for issues #835, #869, #870, #871

### DIFF
--- a/modules/Assay/Parameter.yaml
+++ b/modules/Assay/Parameter.yaml
@@ -71,10 +71,14 @@ enums:
         description: RNA library enriched for lncRNA
       miRNAenrichment:
         description: RNA library with size selection for microRNAs
+      pAG-MNase fragmentation:
+        description: Protein A/G-MNase-based targeted fragmentation of chromatin at antibody-bound sites, used in CUT&RUN assays to profile histone modifications and transcription factor binding.
       polyAselection:
         description: RNA selection by polyA tail capture
       rRNAdepletion:
         description: Total RNA library with ribosomal RNA depleted.
+      Tn5 transposition:
+        description: Library preparation using Tn5 transposase to simultaneously fragment chromatin and insert sequencing adapters, preferentially at open/accessible chromatin regions. Used in ATAC-seq assays.
   LibraryPreparationMethodEnum:
     permissible_values:
       10x:
@@ -116,6 +120,9 @@ enums:
       NEBNext mRNA Library Prep Reagent Set for Illumina:
         description: NEBNext mRNA Library Prep Reagent Set for Illumina
         source: https://www.neb.com/products/e6100-nebnext-mrna-library-prep-reagent-set-for-illumina
+      NEBNext Ultra II DNA Library Prep Kit (E7103) for Illumina:
+        description: New England Biolabs NEBNext Ultra II DNA Library Prep Kit for Illumina (catalog #E7103). Widely used for chromatin immunoprecipitation (CUT&RUN, ChIP-seq) library preparation.
+        source: https://www.neb.com/en-us/products/e7103-nebnext-ultra-ii-dna-library-prep-kit-for-illumina
       Omni-ATAC:
         description: Omni-ATAC-seq library preparation
         source: https://protocolexchange.researchsquare.com/article/nprot-6107/v1

--- a/modules/DCC/Portal.yaml
+++ b/modules/DCC/Portal.yaml
@@ -355,6 +355,9 @@ enums:
       Juvenile Myelomonocytic Leukemia (JMML):
       Low-Grade Glioma:
       Malignant Peripheral Nerve Sheath Tumor (MPNST):
+      Melanoma:
+        description: A malignant tumor composed of neoplastic melanocytes. NF1-mutant melanoma is a clinically recognized manifestation of Neurofibromatosis type 1, where germline NF1 mutations confer elevated melanoma risk due to NF1 tumor suppressor loss in melanocytes.
+        meaning: NCIT:C3224
       Memory:
       Meningioma:
       Pain:

--- a/modules/Sample/Tumor.yaml
+++ b/modules/Sample/Tumor.yaml
@@ -21,6 +21,8 @@ enums:
         - Neurofibroma with Atypia
         description: A neurofibroma characterized by the presence of cellular pleomorphism.
         meaning: NCIT:C41426
+      Atypical MPNST:
+        description: An intermediate-grade malignant peripheral nerve sheath tumor with atypical features that place it between benign neurofibroma and high-grade MPNST. Characterized by increased cellularity, nuclear atypia, and low mitotic activity.
       Atypical Pilocytic Astrocytoma:
         description: Pilocytic astrocytoma with atypical features.
       Cellular Neurofibroma:

--- a/modules/Template/PortalStudy.yaml
+++ b/modules/Template/PortalStudy.yaml
@@ -54,7 +54,7 @@ classes:
         required: true
       manifestation:
         multivalued: true
-        range: string
+        range: ManifestationEnum
         required: false
       nextPhaseProject:
         range: string


### PR DESCRIPTION
## Summary

- **#835** — Add `Atypical MPNST` to `Tumor` enum: intermediate-grade MPNST variant currently used on 14 portal files with no valid schema entry
- **#869** — Add `Melanoma` (NCIT:C3224) to `ManifestationEnum`: NF1-mutant melanoma is a recognized NF1 disease manifestation; also constrains `PortalStudy.manifestation` to `ManifestationEnum` (was `string`) for consistency with `PortalDataset`
- **#870** — Add `Tn5 transposition` and `pAG-MNase fragmentation` to `LibraryPrepEnum` for ATAC-seq and CUT&RUN assays
- **#871** — Add `NEBNext Ultra II DNA Library Prep Kit (E7103) for Illumina` to `LibraryPreparationMethodEnum` for CUT&RUN/ChIP-seq library prep

All issues are from nf-osi/nadia

## Files changed

| File | Change |
|---|---|
| `modules/Sample/Tumor.yaml` | Add `Atypical MPNST` |
| `modules/DCC/Portal.yaml` | Add `Melanoma` to `ManifestationEnum` |
| `modules/Template/PortalStudy.yaml` | Change `manifestation` range from `string` to `ManifestationEnum` |
| `modules/Assay/Parameter.yaml` | Add `Tn5 transposition`, `pAG-MNase fragmentation` to `LibraryPrepEnum`; add NEBNext E7103 kit to `LibraryPreparationMethodEnum` |

## Test plan

- [ ] CI build passes (NF.jsonld, NF.yaml, NF.ttl)
- [ ] Schema limits check passes
- [ ] Verify `PortalStudy` JSON schema now validates `manifestation` against `ManifestationEnum`

🤖 Generated with [Claude Code](https://claude.com/claude-code)