### PR TITLE
Allow tabular fileFormat values in imaging templates (fixes #895)

### DIFF
--- a/modules/Template/Data_Imaging.yaml
+++ b/modules/Template/Data_Imaging.yaml
@@ -30,7 +30,9 @@ classes:
         - range: MRIPlatformEnum
         - range: ImagingSystemPlatformEnum
       fileFormat:
-        range: ImagingFileFormatEnum
+        any_of:
+        - range: ImagingFileFormatEnum
+        - range: TabularFileFormatEnum
       dataType:
         ifabsent: string(image)
     slots:
@@ -79,7 +81,9 @@ classes:
       platform:
         range: MicroscopyImagingPlatformEnum
       fileFormat:
-        range: ImagingFileFormatEnum
+        any_of:
+        - range: ImagingFileFormatEnum
+        - range: TabularFileFormatEnum
       dataType:
         ifabsent: string(image)
     rules:
@@ -137,7 +141,9 @@ classes:
       platform:
         range: MRIPlatformEnum
       fileFormat:
-        range: ImagingFileFormatEnum
+        any_of:
+        - range: ImagingFileFormatEnum
+        - range: TabularFileFormatEnum
       dataType:
         ifabsent: string(image)
     rules:

--- a/registered-json-schemas/ImagingAssayTemplate.json
+++ b/registered-json-schemas/ImagingAssayTemplate.json
@@ -415,17 +415,20 @@
       "type": "string"
     },
     "fileFormat": {
-      "description": "File formats for imaging data including medical imaging and microscopy",
+      "description": "File formats for imaging data including medical imaging, microscopy, and associated tabular metadata",
       "enum": [
         "DICOM",
         "NWB",
         "PAR",
+        "RCC",
         "REC",
         "aci",
         "avi",
         "bmp",
+        "csv",
         "czi",
         "dm3",
+        "excel",
         "hdr",
         "img",
         "jpg",
@@ -433,11 +436,14 @@
         "mov",
         "nii",
         "ome-tiff",
+        "parquet",
         "png",
         "svs",
         "sws",
         "tif",
-        "tom"
+        "tom",
+        "tsv",
+        "txt"
       ],
       "title": "fileFormat",
       "type": "string"

--- a/registered-json-schemas/MRIAssayTemplate.json
+++ b/registered-json-schemas/MRIAssayTemplate.json
@@ -432,17 +432,20 @@
       "type": "string"
     },
     "fileFormat": {
-      "description": "File formats for imaging data including medical imaging and microscopy",
+      "description": "File formats for imaging data including medical imaging, microscopy, and associated tabular metadata",
       "enum": [
         "DICOM",
         "NWB",
         "PAR",
+        "RCC",
         "REC",
         "aci",
         "avi",
         "bmp",
+        "csv",
         "czi",
         "dm3",
+        "excel",
         "hdr",
         "img",
         "jpg",
@@ -450,11 +453,14 @@
         "mov",
         "nii",
         "ome-tiff",
+        "parquet",
         "png",
         "svs",
         "sws",
         "tif",
-        "tom"
+        "tom",
+        "tsv",
+        "txt"
       ],
       "title": "fileFormat",
       "type": "string"

--- a/registered-json-schemas/MicroscopyAssayTemplate.json
+++ b/registered-json-schemas/MicroscopyAssayTemplate.json
@@ -459,17 +459,20 @@
       "type": "string"
     },
     "fileFormat": {
-      "description": "File formats for imaging data including medical imaging and microscopy",
+      "description": "File formats for imaging data including medical imaging, microscopy, and associated tabular metadata",
       "enum": [
         "DICOM",
         "NWB",
         "PAR",
+        "RCC",
         "REC",
         "aci",
         "avi",
         "bmp",
+        "csv",
         "czi",
         "dm3",
+        "excel",
         "hdr",
         "img",
         "jpg",
@@ -477,11 +480,14 @@
         "mov",
         "nii",
         "ome-tiff",
+        "parquet",
         "png",
         "svs",
         "sws",
         "tif",
-        "tom"
+        "tom",
+        "tsv",
+        "txt"
       ],
       "title": "fileFormat",
       "type": "string"


### PR DESCRIPTION
## Summary

Imaging deposits routinely include tabular metadata files — Excel sample sheets, CSV coordinate tables, JSON parameter files — alongside the image files themselves. `ImagingAssayTemplate` (and its subclasses `MicroscopyAssayTemplate`, `MRIAssayTemplate`) previously restricted `fileFormat` to `ImagingFileFormatEnum`, making it impossible to annotate these files correctly.

Fixes #895.

## Changes

**`modules/Template/Data_Imaging.yaml`** — updated `fileFormat` slot_usage in all three imaging template classes to use `any_of` composition, following the same pattern already used for the `platform` slot:

\`\`\`yaml
# Before
fileFormat:
  range: ImagingFileFormatEnum

# After
fileFormat:
  any_of:
    - range: ImagingFileFormatEnum
    - range: TabularFileFormatEnum
\`\`\`

**`registered-json-schemas/`** — updated compiled JSON schemas for the three templates to include the added values (`RCC`, `csv`, `excel`, `parquet`, `tsv`, `txt`). These will also be regenerated by CI on merge.

## Affected templates

| Template | File |
|----------|------|
| `ImagingAssayTemplate` | `modules/Template/Data_Imaging.yaml` |
| `MicroscopyAssayTemplate` | (inherits, overrides fileFormat — updated) |
| `MRIAssayTemplate` | (inherits, overrides fileFormat — updated) |

## New fileFormat values added

From `TabularFileFormatEnum`: `csv`, `excel`, `parquet`, `RCC`, `tsv`, `txt`