### PR TITLE
Add modelSystemName to BulkSequencingAssayTemplate (fixes #897)

### DIFF
--- a/modules/Template/Data_Genomics.yaml
+++ b/modules/Template/Data_Genomics.yaml
@@ -71,6 +71,7 @@ classes:
     - readDepth
     - targetDepth
     - batchID
+    - modelSystemName
     rules:
     - description: Organ is required when specimenType is a tissue (not an organism substance like saliva)
       preconditions:


### PR DESCRIPTION
## Summary

Fixes #897. `modelSystemName` was defined in `props.yaml` and present in the compiled JSON schemas but not explicitly included in `BulkSequencingAssayTemplate`'s `slots` list. Because of this, the registered Synapse schema version 10.8.14 was built without it, preventing curators from annotating model system information on RNA-seq, scRNA-seq, ChIP-seq, and other sequencing assay files.

## Change

Added `- modelSystemName` to `BulkSequencingAssayTemplate.slots` in `modules/Template/Data_Genomics.yaml`. As the parent of `RNASeqTemplate`, `ScRNASeqTemplate`, `GenomicsAssayTemplate`, `GenomicsAssayTemplateExtended`, and others, this single change propagates `modelSystemName` to all child templates.

## Impact

| Template | Currently missing? |
|----------|-------------------|
| RNASeqTemplate | ✓ missing from registered schema |
| ScRNASeqTemplate | ✓ missing |
| BulkSequencingAssayTemplate | ✓ missing |
| GenomicsAssayTemplate | ✓ missing |
| GenomicsAssayTemplateExtended | ✓ missing |
| ChIPSeqTemplate | ✓ missing |
| MethylationArrayTemplate | ✓ missing |

## Why this matters

Model organism RNA-seq is one of the most common data types on the NF portal — NF1/NF2 mouse model studies, xenograft experiments, and patient-derived cell line studies all require `modelSystemName` to identify the specific model system used. Without this field, curators cannot annotate which Nf1+/- mouse strain, cell line, or xenograft model was used, making portal filtering by model system impossible for sequencing data.