### PR TITLE
Add grooming behavior assay term (NBO:0000027)

### DIFF
--- a/modules/Assay/Assay.yaml
+++ b/modules/Assay/Assay.yaml
@@ -532,6 +532,9 @@ enums:
         - GRIPSTR
         description: Assessment of muscle strength that measures that force with which one holds or grasps.
         meaning: NCIT:C139210
+      grooming behavior assay:
+        description: A behavioral assay devised to measure grooming behavior, typically quantifying the frequency, duration, or pattern of self-grooming in an experimental organism.
+        meaning: NBO:0000027
       hand-held dynamometry:
         description: A technique to assess isometric muscle strength using a hand-held dynamometer.
         meaning: NCIT:C186193


### PR DESCRIPTION
## Summary

- Adds `grooming behavior assay` to the `assay` enum in `modules/Assay/Assay.yaml`
- Backed by ontology term **NBO:0000027** (Neuro Behaviour Ontology — grooming behavior)

## Motivation

Needed for Drosophila NF1 model studies that quantify grooming behavior as the primary phenotypic readout (e.g. [PMID:32697780](https://pubmed.ncbi.nlm.nih.gov/32697780/) — *Developmental loss of neurofibromin across distributed neuronal circuits drives excessive grooming in Drosophila*). No existing enum value covered grooming quantification assays; the nearest terms (`novelty response behavior assay`, `active avoidance learning behavior assay`) describe different behavioral paradigms.

## Placement

Inserted alphabetically between `grip strength` and `hand-held dynamometry`.

## Test plan

- [ ] Term appears in compiled `NF.jsonld` / registered schema after build
- [ ] `grooming behavior assay` is selectable in DCA template for BehavioralAssayTemplate