### PR TITLE
Term and template revisions, additions for #889

### DIFF
--- a/modules/Data/Data.yaml
+++ b/modules/Data/Data.yaml
@@ -16,8 +16,15 @@ enums:
         description: Germline variants annotated with some annotation workflow
         source: https://docs.gdc.cancer.gov/Data_Dictionary/viewer/#?view=table-definition-view&id=annotated_germline_variation
       annotated somatic mutation:
-        description: Somatic variants annotated with some annotation workflow
+        description: Sequence variation data from non-germline cell or tissue samples that has been annotated.
+        meaning: NCIT:C184746
         source: https://docs.gdc.cancer.gov/Data_Dictionary/viewer/#?view=table-definition-view&id=annotated_somatic_mutation
+      aggregated somatic mutation:
+        description: Sequence variation data from non-germline cell or tissue samples that has been aggregated across samples, sequencing runs and/or multiple variant callers.
+        meaning: NCIT:C184741
+      masked annotated somatic mutation:
+        description: Annotated nucleotide sequence variation data where potential germline and low-quality base calls have been masked.
+        meaning: NCIT:C184775
       audio transcript:
         description: Text transcript of an audio recording.
         source: https://w3id.org/synapse/nfosi/vocab/audioTranscript

--- a/modules/Data/FileFormat.yaml
+++ b/modules/Data/FileFormat.yaml
@@ -174,6 +174,9 @@ enums:
       dm3:
         description: Gatan DigitalMicrograph file format for electron microscopy images, storing image data along with acquisition metadata and calibration information.
         source: https://www.gatan.com/products/tem-analysis/gatan-microscopy-suite-software
+      emf:
+        description: Enhanced Metafile (EMF) image format used for storing vector graphics.
+        meaning: https://www.iana.org/assignments/media-types/image/emf
       hdr:
         description: MRI Header file, as in the NIFTI-1 Analyze 7.5 format
         source: https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h
@@ -441,6 +444,11 @@ enums:
       abf:
         description: The Axon Binary File format (ABF) was created for the storage of binary experimental data.
         source: https://mdc.custhelp.com/euf/assets/content/ABFHelp.pdf
+      raw:
+        description: Generic raw binary data file from an instrument or acquisition system.
+      spk:
+        description: Spike2 data file format used by CED's data acquisition system for electrophysiology recordings.
+        source: https://ced.co.uk/
       dna:
         description: Propietary SnapGene file format.
         source: https://www.snapgene.com/guides/convert-genbank-files

--- a/modules/Data/Resource.yaml
+++ b/modules/Data/Resource.yaml
@@ -26,6 +26,8 @@ enums:
     permissible_values:
       experimentalData:
         description: Any file derived from or pertaining to a scientific experiment. Experimental data annotations should be applied, possibly disease-related.
+      manifest:
+        description: A metadata manifest file used for validation and annotation of other data files. Different validation rules may apply to manifests compared to experimental data files.
       metadata:
         description: Data about data, information that describes another set of data.
         meaning: NCIT:C52095

--- a/modules/Experiment/Unit.yaml
+++ b/modules/Experiment/Unit.yaml
@@ -19,6 +19,23 @@ enums:
     permissible_values:
       Counts:
         description: Either raw read counts or normalized counts (use the more specific term if possible).
+      CPM:
+        description: Counts per million mapped reads, a simple normalization for sequencing depth.
+      Ct:
+        aliases:
+        - Cq
+        - cycle threshold
+        description: Cycle threshold (Ct) value from quantitative PCR, representing the cycle number at which fluorescence signal crosses a defined threshold.
+      delta Ct:
+        aliases:
+        - ΔCt
+        description: Relative cycle threshold value normalized to a reference gene (target Ct minus reference Ct).
+      delta delta Ct:
+        aliases:
+        - ΔΔCt
+        description: Fold change in expression relative to a control condition, calculated as the difference between sample delta Ct and control delta Ct.
+      fluorescence intensity:
+        description: Fluorescence signal intensity, typically from microarray or imaging-based expression assays.
       FPKM:
         description: Fragments per kilobase of transcript per miilion reads mapped
       Normalized Counts:

--- a/modules/Template/Data_CellAssays.yaml
+++ b/modules/Template/Data_CellAssays.yaml
@@ -154,7 +154,9 @@ classes:
       assay:
         range: CellBasedAssayEnum
       fileFormat:
-        range: OtherFileFormatEnum
+        any_of:
+        - range: OtherFileFormatEnum
+        - range: TabularFileFormatEnum
     rules:
     - description: If experimentalTimepoint is provided, timepointUnit must be provided
       preconditions:
@@ -208,6 +210,7 @@ classes:
         range: CellBasedAssayEnum
       platform:
         range: PlateReaderPlatformEnum
+        required: false
       fileFormat:
         range: TabularFileFormatEnum
       individualID:

--- a/modules/Template/Data_Genomics.yaml
+++ b/modules/Template/Data_Genomics.yaml
@@ -728,8 +728,6 @@ classes:
 
   ProcessedAggregatedDataTemplate:
     annotations:
-      required: false
-      requiresComponent: ''
       templateUsage: common
       templateFor:
         dataType:

--- a/modules/Template/Data_Genomics.yaml
+++ b/modules/Template/Data_Genomics.yaml
@@ -671,6 +671,8 @@ classes:
     slot_usage:
       dataSubtype:
         ifabsent: string(processed)
+      expressionUnit:
+        required: true
     rules:
     - description: If workflow is provided, workflowLink must be provided
       preconditions:
@@ -713,6 +715,49 @@ classes:
     slot_usage:
       dataSubtype:
         ifabsent: string(processed)
+    rules:
+    - description: If workflow is provided, workflowLink must be provided
+      preconditions:
+        slot_conditions:
+          workflow:
+            value_presence: PRESENT
+      postconditions:
+        slot_conditions:
+          workflowLink:
+            value_presence: PRESENT
+
+  ProcessedAggregatedDataTemplate:
+    annotations:
+      required: false
+      requiresComponent: ''
+      templateUsage: common
+      templateFor:
+        dataType:
+        - aggregated somatic mutation
+        assay:
+        - quantitative PCR
+      dataGranularity: aggregate-level
+    description: Template for processed data aggregated across multiple specimens
+      into a single file, where individual-level attributes (specimenID, individualID)
+      do not apply. Use for summarized assay results such as qPCR Ct value tables.
+    is_a: FileBasedTemplate
+    slots:
+    - dataType
+    - dataSubtype
+    - assay
+    - expressionUnit
+    - workflow
+    - workflowLink
+    - auxiliaryAsset
+    - species
+    - comments
+    slot_usage:
+      dataSubtype:
+        ifabsent: string(processed)
+      expressionUnit:
+        required: false
+      species:
+        required: false
     rules:
     - description: If workflow is provided, workflowLink must be provided
       preconditions:

--- a/modules/Template/Data_Imaging.yaml
+++ b/modules/Template/Data_Imaging.yaml
@@ -79,7 +79,9 @@ classes:
       assay:
         range: ImagingAssayEnum
       platform:
-        range: MicroscopyImagingPlatformEnum
+        any_of:
+        - range: MicroscopyImagingPlatformEnum
+        - range: OtherPlatformEnum
       fileFormat:
         any_of:
         - range: ImagingFileFormatEnum

--- a/modules/Template/Data_Misc.yaml
+++ b/modules/Template/Data_Misc.yaml
@@ -50,7 +50,7 @@ classes:
       species:
         required: false
 
-  ResultTemplate:
+  AnalysisResultTemplate:
     annotations:
       templateUsage: common
       templateFor:
@@ -63,15 +63,13 @@ classes:
     slots:
     - dataType
     - dataSubtype
-    - assay
     - species
+    - relatedDataset
     - comments
     slot_usage:
       resourceType:
         ifabsent: string(result)
       species:
-        required: false
-      assay:
         required: false
       fileFormat:
         any_of:

--- a/modules/Template/Data_Misc.yaml
+++ b/modules/Template/Data_Misc.yaml
@@ -50,6 +50,37 @@ classes:
       species:
         required: false
 
+  ResultTemplate:
+    annotations:
+      required: false
+      requiresComponent: ''
+      templateUsage: common
+      templateFor:
+        dataType:
+        - image
+        - report
+    description: Template for result files such as figures, presentations, and analysis
+      outputs that report data results but are not primary experimental data.
+    is_a: FileBasedTemplate
+    slots:
+    - dataType
+    - dataSubtype
+    - assay
+    - species
+    - comments
+    slot_usage:
+      resourceType:
+        ifabsent: string(result)
+      species:
+        required: false
+      assay:
+        required: false
+      fileFormat:
+        any_of:
+        - range: ImagingFileFormatEnum
+        - range: DocumentFileFormatEnum
+        - range: TabularFileFormatEnum
+
   UpdateMilestoneReport:
     annotations:
       required: false

--- a/modules/Template/Data_Misc.yaml
+++ b/modules/Template/Data_Misc.yaml
@@ -52,8 +52,6 @@ classes:
 
   ResultTemplate:
     annotations:
-      required: false
-      requiresComponent: ''
       templateUsage: common
       templateFor:
         dataType:

--- a/tests/data/ProcessedAggregatedDataTemplate/invalid_workflow_missing_link.json
+++ b/tests/data/ProcessedAggregatedDataTemplate/invalid_workflow_missing_link.json
@@ -1,0 +1,8 @@
+{
+  "assay": "quantitative PCR",
+  "dataSubtype": "processed",
+  "dataType": "quantified gene expression",
+  "fileFormat": "csv",
+  "resourceType": "experimentalData",
+  "workflow": "DESeq2"
+}

--- a/tests/data/ProcessedAggregatedDataTemplate/valid_qpcr_summary.json
+++ b/tests/data/ProcessedAggregatedDataTemplate/valid_qpcr_summary.json
@@ -1,0 +1,7 @@
+{
+  "assay": "quantitative PCR",
+  "dataSubtype": "processed",
+  "dataType": "quantified gene expression",
+  "fileFormat": "csv",
+  "resourceType": "experimentalData"
+}

--- a/tests/data/ProcessedAggregatedDataTemplate/valid_with_workflow.json
+++ b/tests/data/ProcessedAggregatedDataTemplate/valid_with_workflow.json
@@ -1,0 +1,9 @@
+{
+  "assay": "quantitative PCR",
+  "dataSubtype": "processed",
+  "dataType": "quantified gene expression",
+  "fileFormat": "csv",
+  "resourceType": "experimentalData",
+  "workflow": "DESeq2",
+  "workflowLink": "https://bioconductor.org/packages/DESeq2"
+}

--- a/tests/test_registry_processed_aggregated.yaml
+++ b/tests/test_registry_processed_aggregated.yaml
@@ -1,0 +1,20 @@
+
+# ProcessedAggregatedDataTemplate Validation
+#
+# Tests that the template works for aggregate-level data (e.g. qPCR summaries)
+# without requiring specimenID or individualID.
+
+schema: ProcessedAggregatedDataTemplate
+instances:
+  - file: data/ProcessedAggregatedDataTemplate/valid_qpcr_summary.json
+    description: Minimal valid qPCR summary — no specimenID or individualID needed
+    expected: valid
+
+  - file: data/ProcessedAggregatedDataTemplate/valid_with_workflow.json
+    description: Valid with workflow and workflowLink both provided
+    expected: valid
+
+  - file: data/ProcessedAggregatedDataTemplate/invalid_workflow_missing_link.json
+    description: Workflow provided but workflowLink missing — violates conditional dependency
+    expected: invalid
+    reason: workflow is present but workflowLink is missing


### PR DESCRIPTION
See #889 - a bit of a hodgepodge: 

- Many term additions and making sure templates have access to the file enums they need. 
- For @changtotheintothemoon, relevant to your issue #825, this does add `manifest` to `resourceType` since it's special enough to label more specifically than `metadata` - so you can relax validation for `manifest` as well as the other ones already planned. 
- Relaxed `platform` req for PlateBasedReporterAssayTemplate (where it's not as crucial as for sequencing/imaging), but on the other hand became a little stricter on requiring `expressionUnit` for processed data. 
- Added two templates to better handle other processed/result data. 