### PR TITLE
Add University of Auckland to Institution enum

### DIFF
--- a/modules/Other/Organization.yaml
+++ b/modules/Other/Organization.yaml
@@ -413,6 +413,8 @@ enums:
         meaning: ''
       University of Arkansas, Fayetteville:
         meaning: ''
+      University of Auckland:
+        meaning: https://ror.org/03b94tp07
       University of Baltimore:
         meaning: ''
       University of California, Berkeley:


### PR DESCRIPTION
## Summary
- Adds **University of Auckland** to the `Institution` permissible values in `modules/Other/Organization.yaml`
- Includes ROR ID: https://ror.org/03b94tp07
- Inserted in alphabetical order between "University of Arkansas, Fayetteville" and "University of Baltimore"

## Test plan
- [x] Verify YAML is valid and CI passes
- [ ] Confirm the term appears in built artifacts after merge
