### PR TITLE
feat: Add log, out, sh fileFormat values for co-located auxiliary files

### DIFF
--- a/modules/Data/FileFormat.yaml
+++ b/modules/Data/FileFormat.yaml
@@ -280,6 +280,10 @@ enums:
         - This file format encompasses/includes the h5ad anndata format commonly used for scRNAseq data sharing.
       idx:
         description: ''
+      log:
+        description: Plain-text log file recording messages, events, or diagnostic output produced by a tool, pipeline, or acquisition system. Commonly co-located with primary data as an auxiliary file.
+      out:
+        description: Generic output file (often standard output or a tool-specific dump) produced by a program or workflow step. Commonly co-located with primary data as an auxiliary file.
       psydat:
         description: TrialHandler or StairHandler object that has been saved to disk with the python cPickle module, ideal for batch analysis and plotting with Python.
         notes:
@@ -335,6 +339,9 @@ enums:
         description: R script with expected extension “.R”.
         meaning: EDAM:format_3999
       bash script:
+        aliases:
+        - sh
+        - shell script
         description: Bash shell script with .sh extension.
         source: https://en.wikipedia.org/wiki/Shell_script
       js:


### PR DESCRIPTION
## Summary

Adds missing `fileFormat` enum values for auxiliary files that commonly sit alongside primary data within a dataset folder (see #825). This is the small, low-risk first step of the #825 work; the conditional relaxed-validation refactor follows in a separate PR.

### Changes (`modules/Data/FileFormat.yaml`)
- **`log`** (`OtherFileFormatEnum`) — plain-text log files (messages/events/diagnostics).
- **`out`** (`OtherFileFormatEnum`) — generic program/workflow output dumps.
- **`sh`** / **`shell script`** — added as `aliases` on the existing `bash script` value (which already documents the `.sh` extension), rather than a duplicate value.

`manifest` is intentionally **not** added here — it is a `resourceType` (added in #901), and manifest files use existing formats (`csv`/`tsv`/`xlsx`).

### Why
Auxiliary files (`manifest.csv`, `.out`, `.log`, `.sh`) currently have no valid `fileFormat` option for logs/outputs, contributing to validation noise. These additions give curators correct options and are a prerequisite for relaxed conditional validation.

## Test plan
- [x] `make -B NF.yaml` rebuilds the merged schema cleanly
- [x] `python utils/gen-json-schema-class.py` regenerates schemas; `log`/`out` appear in `fileFormat` enums (Synapse registration step is auth-gated locally and unrelated)
- [x] `pytest tests/test_schema_instances.py tests/test_template_datatypes.py tests/test_model_system_sync.py` → 24 passed, 16 xfailed
- Artifacts (`dist/`, `registered-json-schemas/`) intentionally not committed — rebuilt by the on-main workflow, consistent with #901.

Part of #825.