### PR TITLE
feat: Relaxed conditional validation for co-located auxiliary files (#825)

### DIFF
--- a/modules/Template/Data_Base.yaml
+++ b/modules/Template/Data_Base.yaml
@@ -27,9 +27,9 @@ classes:
     description: 'A template defining basic metadata on deposited data artifacts (i.e.
       files) from experimental assays involving biosamples. Donor/individual attributes
       (species, sex, age, diagnosis) describe the original donor (e.g., human patient
-      tumor). For cell lines, individualID references syn51730943. antibodyID
-      and geneticReagentID reference treatments/reagents. For PDX data, use
-      PdxGenomicsAssayTemplate which includes model* attributes.'
+      tumor). For cell lines, individualID references syn51730943. antibodyID and
+      geneticReagentID reference treatments/reagents. For PDX data, use PdxGenomicsAssayTemplate
+      which includes model* attributes.'
     is_a: FileBasedTemplate
     slots:
     - dataType
@@ -55,12 +55,13 @@ classes:
           age:
             value_presence: PRESENT
             none_of:
-              - equals_string: Unknown
+            - equals_string: Unknown
       postconditions:
         slot_conditions:
           ageUnit:
             value_presence: PRESENT
-    - description: For Homo sapiens, age must be < 90; use the ">= 90" AgeMask value for ages at or above this threshold (HIPAA Safe Harbor)
+    - description: For Homo sapiens, age must be < 90; use the ">= 90" AgeMask value
+        for ages at or above this threshold (HIPAA Safe Harbor)
       preconditions:
         slot_conditions:
           species:
@@ -78,9 +79,47 @@ classes:
         slot_conditions:
           dataSubtype:
             value_presence: PRESENT
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          dataType:
+            value_presence: PRESENT
+          dataSubtype:
+            value_presence: PRESENT
+          assay:
+            value_presence: PRESENT
+          individualID:
+            value_presence: PRESENT
+          species:
+            value_presence: PRESENT
+          diagnosis:
+            value_presence: PRESENT
+          tumorType:
+            value_presence: PRESENT
     annotations:
       dataGranularity: specimen-level
 
+    slot_usage:
+      dataType:
+        required: false
+      dataSubtype:
+        required: false
+      assay:
+        required: false
+      individualID:
+        required: false
+      species:
+        required: false
+      diagnosis:
+        required: false
+      tumorType:
+        required: false
   NonBiologicalAssayDataTemplate:
     abstract: true
     description: 'Describes data artifacts (i.e. files) from an experimental/physical-sciences
@@ -97,3 +136,26 @@ classes:
     - assay
     annotations:
       dataGranularity: specimen-level
+    slot_usage:
+      dataType:
+        required: false
+      dataSubtype:
+        required: false
+      assay:
+        required: false
+    rules:
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          dataType:
+            value_presence: PRESENT
+          dataSubtype:
+            value_presence: PRESENT
+          assay:
+            value_presence: PRESENT

--- a/modules/Template/Data_CellAssays.yaml
+++ b/modules/Template/Data_CellAssays.yaml
@@ -22,7 +22,8 @@ classes:
         - in vivo tumor growth
         - in vitro tumorigenesis
       dataGranularity: specimen-level
-    description: 'Data that characterizes cell/tissue morphology or physiology often in the context of different experimental conditions'
+    description: 'Data that characterizes cell/tissue morphology or physiology often
+      in the context of different experimental conditions'
     is_a: BiologicalAssayDataTemplate
     slots:
     - parentSpecimenID
@@ -97,6 +98,20 @@ classes:
           specimenID:
             value_presence: PRESENT
 
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          specimenID:
+            value_presence: PRESENT
+    slot_usage:
+      specimenID:
+        required: false
   FlowCytometryTemplate:
     annotations:
       required: false
@@ -122,9 +137,22 @@ classes:
         ifabsent: string(flow cytometry)
       platform:
         range: FlowCytometryPlatformEnum
+        required: false
       fileFormat:
         range: OtherFileFormatEnum
 
+    rules:
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          platform:
+            value_presence: PRESENT
   ElectrophysiologyAssayTemplate:
     annotations:
       templateUsage: common
@@ -157,6 +185,8 @@ classes:
         any_of:
         - range: OtherFileFormatEnum
         - range: TabularFileFormatEnum
+      platform:
+        required: false
     rules:
     - description: If experimentalTimepoint is provided, timepointUnit must be provided
       preconditions:
@@ -168,6 +198,17 @@ classes:
           timepointUnit:
             value_presence: PRESENT
 
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          platform:
+            value_presence: PRESENT
   PlateBasedReporterAssayTemplate:
     annotations:
       required: false
@@ -216,11 +257,13 @@ classes:
       individualID:
         required: false
       compoundName:
-        required: true
+        required: false
       compoundDose:
-        required: true
+        required: false
       compoundDoseUnit:
-        required: true
+        required: false
+      specimenID:
+        required: false
     rules:
     - description: If experimentalTimepoint is provided, timepointUnit must be provided
       preconditions:
@@ -238,5 +281,22 @@ classes:
             value_presence: PRESENT
       postconditions:
         slot_conditions:
+          compoundDoseUnit:
+            value_presence: PRESENT
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          specimenID:
+            value_presence: PRESENT
+          compoundName:
+            value_presence: PRESENT
+          compoundDose:
+            value_presence: PRESENT
           compoundDoseUnit:
             value_presence: PRESENT

--- a/modules/Template/Data_Clinical.yaml
+++ b/modules/Template/Data_Clinical.yaml
@@ -143,9 +143,26 @@ classes:
     slot_usage:
       dataType:
         ifabsent: string(epidemiological data)
+        required: false
+      epidemiologyMetric:
+        required: false
     annotations:
       templateUsage: specialized
       templateFor:
         dataType:
         - epidemiological data
       dataGranularity: population-level
+    rules:
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          dataType:
+            value_presence: PRESENT
+          epidemiologyMetric:
+            value_presence: PRESENT

--- a/modules/Template/Data_Genomics.yaml
+++ b/modules/Template/Data_Genomics.yaml
@@ -1,4 +1,3 @@
-
 classes:
   GeneticsAssayTemplate:
     abstract: true
@@ -29,9 +28,30 @@ classes:
         range: SequencingAssayEnum
       platform:
         range: SequencingPlatformEnum
+        required: false
       fileFormat:
         range: SequencingFileFormatEnum
 
+      specimenID:
+        required: false
+      specimenPreparationMethod:
+        required: false
+    rules:
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          specimenID:
+            value_presence: PRESENT
+          platform:
+            value_presence: PRESENT
+          specimenPreparationMethod:
+            value_presence: PRESENT
   BulkSequencingAssayTemplate:
     annotations:
       required: false
@@ -60,6 +80,10 @@ classes:
         range: SequencingPlatformEnum
       fileFormat:
         range: SequencingFileFormatEnum
+      libraryStrand:
+        required: false
+      libraryPreparationMethod:
+        required: false
     slots:
     - specimenType
     - runType
@@ -73,22 +97,36 @@ classes:
     - batchID
     - modelSystemName
     rules:
-    - description: Organ is required when specimenType is a tissue (not an organism substance like saliva)
+    - description: Organ is required when specimenType is a tissue (not an organism
+        substance like saliva)
       preconditions:
         slot_conditions:
           specimenType:
             value_presence: PRESENT
             none_of:
-              - equals_string: mucus
-              - equals_string: saliva
-              - equals_string: stool
-              - equals_string: sweat
-              - equals_string: urine
+            - equals_string: mucus
+            - equals_string: saliva
+            - equals_string: stool
+            - equals_string: sweat
+            - equals_string: urine
       postconditions:
         slot_conditions:
           organ:
             value_presence: PRESENT
 
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          libraryStrand:
+            value_presence: PRESENT
+          libraryPreparationMethod:
+            value_presence: PRESENT
   GenomicsArrayTemplate:
     annotations:
       required: false
@@ -120,6 +158,20 @@ classes:
       fileFormat:
         range: ArrayFileFormatEnum
 
+      channel:
+        required: false
+    rules:
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          channel:
+            value_presence: PRESENT
   GenomicsAssayTemplate:
     annotations:
       required: false
@@ -357,6 +409,28 @@ classes:
       fileFormat:
         range: SequencingFileFormatEnum
 
+      libraryStrand:
+        required: false
+      libraryKitID:
+        required: false
+      libraryPreparationMethod:
+        required: false
+    rules:
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          libraryStrand:
+            value_presence: PRESENT
+          libraryKitID:
+            value_presence: PRESENT
+          libraryPreparationMethod:
+            value_presence: PRESENT
   ScRNASeqTemplate:
     annotations:
       required: false
@@ -435,8 +509,20 @@ classes:
       dataType:
         ifabsent: string(genomic variants)
       targetCaptureKitID:
-        required: true
+        required: false
 
+    rules:
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          targetCaptureKitID:
+            value_presence: PRESENT
   WGSTemplate:
     annotations:
       required: false
@@ -548,7 +634,7 @@ classes:
     - chipPosition
     - plateName
     - plateWell
-    source:
+    source: 
       https://docs.gdc.cancer.gov/Data_Dictionary/viewer/#?view=table-definition-view&id=raw_methylation_array
     slot_usage:
       assay:
@@ -619,6 +705,10 @@ classes:
         ifabsent: string(processed)
       fileFormat:
         range: SequencingFileFormatEnum
+      genomicReference:
+        required: false
+      specimenID:
+        required: false
     rules:
     - description: If workflow is provided, workflowLink must be provided
       preconditions:
@@ -639,6 +729,19 @@ classes:
           genomicReferenceLink:
             value_presence: PRESENT
 
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          genomicReference:
+            value_presence: PRESENT
+          specimenID:
+            value_presence: PRESENT
   ProcessedGeneExpressionTemplate:
     annotations:
       required: false
@@ -672,7 +775,9 @@ classes:
       dataSubtype:
         ifabsent: string(processed)
       expressionUnit:
-        required: true
+        required: false
+      specimenID:
+        required: false
     rules:
     - description: If workflow is provided, workflowLink must be provided
       preconditions:
@@ -684,6 +789,19 @@ classes:
           workflowLink:
             value_presence: PRESENT
 
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          expressionUnit:
+            value_presence: PRESENT
+          specimenID:
+            value_presence: PRESENT
   ProcessedMergedDataTemplate:
     annotations:
       required: false
@@ -715,6 +833,11 @@ classes:
     slot_usage:
       dataSubtype:
         ifabsent: string(processed)
+        required: false
+      dataType:
+        required: false
+      assay:
+        required: false
     rules:
     - description: If workflow is provided, workflowLink must be provided
       preconditions:
@@ -726,6 +849,21 @@ classes:
           workflowLink:
             value_presence: PRESENT
 
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          dataType:
+            value_presence: PRESENT
+          dataSubtype:
+            value_presence: PRESENT
+          assay:
+            value_presence: PRESENT
   ProcessedAggregatedDataTemplate:
     annotations:
       templateUsage: common
@@ -752,9 +890,14 @@ classes:
     slot_usage:
       dataSubtype:
         ifabsent: string(processed)
+        required: false
       expressionUnit:
         required: false
       species:
+        required: false
+      dataType:
+        required: false
+      assay:
         required: false
     rules:
     - description: If workflow is provided, workflowLink must be provided
@@ -767,6 +910,21 @@ classes:
           workflowLink:
             value_presence: PRESENT
 
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          dataType:
+            value_presence: PRESENT
+          dataSubtype:
+            value_presence: PRESENT
+          assay:
+            value_presence: PRESENT
   ProcessedVariantCallsTemplate:
     annotations:
       required: false
@@ -803,6 +961,8 @@ classes:
         ifabsent: string(processed)
       fileFormat:
         range: SequencingFileFormatEnum
+      specimenID:
+        required: false
     rules:
     - description: If workflow is provided, workflowLink must be provided
       preconditions:
@@ -812,4 +972,15 @@ classes:
       postconditions:
         slot_conditions:
           workflowLink:
+            value_presence: PRESENT
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          specimenID:
             value_presence: PRESENT

--- a/modules/Template/Data_Imaging.yaml
+++ b/modules/Template/Data_Imaging.yaml
@@ -29,6 +29,7 @@ classes:
         - range: MicroscopyImagingPlatformEnum
         - range: MRIPlatformEnum
         - range: ImagingSystemPlatformEnum
+        required: false
       fileFormat:
         any_of:
         - range: ImagingFileFormatEnum
@@ -40,6 +41,18 @@ classes:
     - assayTarget
     - auxiliaryAsset
 
+    rules:
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          platform:
+            value_presence: PRESENT
   MicroscopyAssayTemplate:
     annotations:
       required: false
@@ -61,8 +74,8 @@ classes:
       dataGranularity: specimen-level
     close_mappings:
     - htan:ImagingLevel2
-    description: Template for microscopy imaging data. For immunofluorescence or
-      immunohistochemistry assays, provide antibodyID.
+    description: Template for microscopy imaging data. For immunofluorescence or immunohistochemistry
+      assays, provide antibodyID.
     is_a: ImagingAssayTemplate
     slots:
     - parentSpecimenID
@@ -88,6 +101,8 @@ classes:
         - range: TabularFileFormatEnum
       dataType:
         ifabsent: string(image)
+      specimenID:
+        required: false
     rules:
     - description: If workingDistance is provided, workingDistanceUnit must be provided
       preconditions:
@@ -117,6 +132,17 @@ classes:
           specimenID:
             value_presence: PRESENT
 
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          specimenID:
+            value_presence: PRESENT
   MRIAssayTemplate:
     annotations:
       required: false

--- a/modules/Template/Data_MaterialScience.yaml
+++ b/modules/Template/Data_MaterialScience.yaml
@@ -45,6 +45,24 @@ classes:
           concentrationNaClUnit:
             value_presence: PRESENT
 
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          specimenID:
+            value_presence: PRESENT
+          platform:
+            value_presence: PRESENT
+    slot_usage:
+      specimenID:
+        required: false
+      platform:
+        required: false
   LightScatteringAssayTemplate:
     annotations:
       required: false

--- a/modules/Template/Data_Misc.yaml
+++ b/modules/Template/Data_Misc.yaml
@@ -23,6 +23,28 @@ classes:
       resourceType:
         ifabsent: string(experimentalData)
 
+      dataType:
+        required: false
+      dataSubtype:
+        required: false
+      assay:
+        required: false
+    rules:
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          dataType:
+            value_presence: PRESENT
+          dataSubtype:
+            value_presence: PRESENT
+          assay:
+            value_presence: PRESENT
   ReferenceSequenceTemplate:
     annotations:
       required: false
@@ -50,6 +72,20 @@ classes:
       species:
         required: false
 
+      dataType:
+        required: false
+    rules:
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          dataType:
+            value_presence: PRESENT
   AnalysisResultTemplate:
     annotations:
       templateUsage: common
@@ -77,6 +113,24 @@ classes:
         - range: DocumentFileFormatEnum
         - range: TabularFileFormatEnum
 
+      dataType:
+        required: false
+      dataSubtype:
+        required: false
+    rules:
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          dataType:
+            value_presence: PRESENT
+          dataSubtype:
+            value_presence: PRESENT
   UpdateMilestoneReport:
     annotations:
       required: false
@@ -107,6 +161,8 @@ classes:
     slot_usage:
       resourceType:
         ifabsent: string(report)
+      assay:
+        required: false
     rules:
     - description: If workflow is provided, workflowLink must be provided
       preconditions:
@@ -116,6 +172,17 @@ classes:
       postconditions:
         slot_conditions:
           workflowLink:
+            value_presence: PRESENT
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          assay:
             value_presence: PRESENT
     annotations:
       templateUsage: specialized

--- a/modules/Template/Data_Proteomics.yaml
+++ b/modules/Template/Data_Proteomics.yaml
@@ -19,9 +19,26 @@ classes:
         range: MassSpectrometryAssayEnum
       platform:
         range: MassSpectrometryPlatformEnum
+        required: false
       fileFormat:
         range: MassSpecFileFormatEnum
 
+      specimenID:
+        required: false
+    rules:
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          specimenID:
+            value_presence: PRESENT
+          platform:
+            value_presence: PRESENT
   MassSpecAssayTemplate:
     annotations:
       required: false
@@ -58,6 +75,20 @@ classes:
       fileFormat:
         range: MassSpecFileFormatEnum
 
+      dataCollectionMode:
+        required: false
+    rules:
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          dataCollectionMode:
+            value_presence: PRESENT
   ProteomicsAssayTemplate:
     annotations:
       required: false

--- a/modules/Template/Data_SpatialTranscriptomics.yaml
+++ b/modules/Template/Data_SpatialTranscriptomics.yaml
@@ -12,9 +12,9 @@ classes:
       dataGranularity: specimen-level
     close_mappings:
     - htan:VisiumSpatialTranscriptomicsLevel1
-    description: Template for describing sequencing-based and expression data files from
-      spatial transcriptomics experiments (e.g., FASTQ files and count matrices from 10x
-      Visium, 10x Visium CytAssist, NanoString CosMx, GeoMx).
+    description: Template for describing sequencing-based and expression data files
+      from spatial transcriptomics experiments (e.g., FASTQ files and count matrices
+      from 10x Visium, 10x Visium CytAssist, NanoString CosMx, GeoMx).
     is_a: GeneticsAssayTemplate
     slots:
     - captureArea
@@ -36,6 +36,20 @@ classes:
       dataType:
         ifabsent: string(gene expression)
 
+      libraryPreparationMethod:
+        required: false
+    rules:
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          libraryPreparationMethod:
+            value_presence: PRESENT
   SpatialTranscriptomicsImagingTemplate:
     annotations:
       required: false
@@ -48,8 +62,8 @@ classes:
         - spatial transcriptomics
       dataGranularity: specimen-level
     description: Template for describing imaging data files from spatial transcriptomics
-      experiments, such as tissue section histology or fluorescence images (e.g., from
-      10x Visium, NanoString CosMx, GeoMx).
+      experiments, such as tissue section histology or fluorescence images (e.g.,
+      from 10x Visium, NanoString CosMx, GeoMx).
     is_a: ImagingAssayTemplate
     slots:
     - parentSpecimenID
@@ -69,3 +83,17 @@ classes:
         range: ImagingFileFormatEnum
       dataType:
         ifabsent: string(image)
+      specimenID:
+        required: false
+    rules:
+    - description: 'Relaxed conditional validation (issue #825): the listed fields
+        are required only for experimentalData. Auxiliary co-located files (manifest,
+        metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
+      preconditions:
+        slot_conditions:
+          resourceType:
+            equals_string: experimentalData
+      postconditions:
+        slot_conditions:
+          specimenID:
+            value_presence: PRESENT

--- a/tests/data/MaterialScienceAssayTemplate/invalid_experimentaldata_missing_required.json
+++ b/tests/data/MaterialScienceAssayTemplate/invalid_experimentaldata_missing_required.json
@@ -1,0 +1,4 @@
+{
+  "resourceType": "experimentalData",
+  "fileFormat": "csv"
+}

--- a/tests/data/MaterialScienceAssayTemplate/valid_metadata_relaxed.json
+++ b/tests/data/MaterialScienceAssayTemplate/valid_metadata_relaxed.json
@@ -1,0 +1,4 @@
+{
+  "resourceType": "metadata",
+  "fileFormat": "csv"
+}

--- a/tests/data/PlateBasedReporterAssayTemplate/invalid_experimentaldata_missing_compound.json
+++ b/tests/data/PlateBasedReporterAssayTemplate/invalid_experimentaldata_missing_compound.json
@@ -1,0 +1,13 @@
+{
+  "resourceType": "experimentalData",
+  "fileFormat": "csv",
+  "dataType": "drug screen",
+  "dataSubtype": "raw",
+  "assay": "high content screen",
+  "individualID": ["NF-001"],
+  "species": "Homo sapiens",
+  "diagnosis": "Neurofibromatosis type 1",
+  "tumorType": "Plexiform Neurofibroma",
+  "specimenID": "NF-001-T1",
+  "specimenPreparationMethod": "fresh frozen"
+}

--- a/tests/data/PlateBasedReporterAssayTemplate/valid_manifest_relaxed.json
+++ b/tests/data/PlateBasedReporterAssayTemplate/valid_manifest_relaxed.json
@@ -1,0 +1,4 @@
+{
+  "resourceType": "manifest",
+  "fileFormat": "csv"
+}

--- a/tests/data/ProcessedAggregatedDataTemplate/invalid_experimentaldata_missing_required.json
+++ b/tests/data/ProcessedAggregatedDataTemplate/invalid_experimentaldata_missing_required.json
@@ -1,0 +1,4 @@
+{
+  "resourceType": "experimentalData",
+  "fileFormat": "csv"
+}

--- a/tests/data/ProcessedAggregatedDataTemplate/invalid_manifest_missing_fileformat.json
+++ b/tests/data/ProcessedAggregatedDataTemplate/invalid_manifest_missing_fileformat.json
@@ -1,0 +1,3 @@
+{
+  "resourceType": "manifest"
+}

--- a/tests/data/ProcessedAggregatedDataTemplate/invalid_missing_resourcetype.json
+++ b/tests/data/ProcessedAggregatedDataTemplate/invalid_missing_resourcetype.json
@@ -1,0 +1,3 @@
+{
+  "fileFormat": "csv"
+}

--- a/tests/data/ProcessedAggregatedDataTemplate/valid_manifest_relaxed.json
+++ b/tests/data/ProcessedAggregatedDataTemplate/valid_manifest_relaxed.json
@@ -1,0 +1,4 @@
+{
+  "resourceType": "manifest",
+  "fileFormat": "csv"
+}

--- a/tests/data/ProcessedAggregatedDataTemplate/valid_workflowreport_relaxed.json
+++ b/tests/data/ProcessedAggregatedDataTemplate/valid_workflowreport_relaxed.json
@@ -1,0 +1,4 @@
+{
+  "resourceType": "workflow report",
+  "fileFormat": "csv"
+}

--- a/tests/data/WGSTemplate/invalid_experimentaldata_missing_required.json
+++ b/tests/data/WGSTemplate/invalid_experimentaldata_missing_required.json
@@ -1,0 +1,4 @@
+{
+  "resourceType": "experimentalData",
+  "fileFormat": "bam"
+}

--- a/tests/data/WGSTemplate/valid_metadata_relaxed.json
+++ b/tests/data/WGSTemplate/valid_metadata_relaxed.json
@@ -1,0 +1,4 @@
+{
+  "resourceType": "metadata",
+  "fileFormat": "bam"
+}

--- a/tests/test_registry_resourcetype_relaxed.yaml
+++ b/tests/test_registry_resourcetype_relaxed.yaml
@@ -1,0 +1,58 @@
+# Relaxed conditional validation by resourceType (issue #825)
+#
+# Co-located auxiliary files (manifest.csv, .log, .out, etc.) carry a
+# non-experimentalData resourceType (manifest, metadata, report, workflow
+# report, tool, result, weblink, protocol) and should validate with only
+# fileFormat + resourceType required. experimentalData files keep the full
+# template requirements (re-required via resourceType-conditional rules).
+
+schema: ProcessedAggregatedDataTemplate
+instances:
+  - file: data/ProcessedAggregatedDataTemplate/valid_manifest_relaxed.json
+    description: Manifest co-located file — only fileFormat + resourceType required
+    expected: valid
+  - file: data/ProcessedAggregatedDataTemplate/valid_workflowreport_relaxed.json
+    description: Workflow report file — relaxed validation
+    expected: valid
+  - file: data/ProcessedAggregatedDataTemplate/invalid_experimentaldata_missing_required.json
+    description: experimentalData still requires dataType/dataSubtype/assay
+    expected: invalid
+    reason: resourceType is experimentalData but dataType/dataSubtype/assay missing
+  - file: data/ProcessedAggregatedDataTemplate/invalid_manifest_missing_fileformat.json
+    description: fileFormat stays unconditionally required even for auxiliary files
+    expected: invalid
+    reason: fileFormat is required for all resource types
+  - file: data/ProcessedAggregatedDataTemplate/invalid_missing_resourcetype.json
+    description: resourceType is the discriminator and stays unconditionally required
+    expected: invalid
+    reason: resourceType is required for all file templates
+---
+schema: WGSTemplate
+instances:
+  - file: data/WGSTemplate/valid_metadata_relaxed.json
+    description: Auxiliary metadata file in a genomics folder — genetics-tier fields (specimenID, platform, libraryStrand, ...) not required
+    expected: valid
+  - file: data/WGSTemplate/invalid_experimentaldata_missing_required.json
+    description: experimentalData still requires the full genomics annotation set
+    expected: invalid
+    reason: resourceType is experimentalData but specimenID/platform/library*/etc. missing
+---
+schema: MaterialScienceAssayTemplate
+instances:
+  - file: data/MaterialScienceAssayTemplate/valid_metadata_relaxed.json
+    description: Non-biological assay — auxiliary file relaxed (specimenID/platform not required)
+    expected: valid
+  - file: data/MaterialScienceAssayTemplate/invalid_experimentaldata_missing_required.json
+    description: experimentalData still requires specimenID/platform/dataType/dataSubtype/assay
+    expected: invalid
+    reason: resourceType is experimentalData but required annotations missing
+---
+schema: PlateBasedReporterAssayTemplate
+instances:
+  - file: data/PlateBasedReporterAssayTemplate/valid_manifest_relaxed.json
+    description: Manifest in a plate-based reporter folder — compound* and specimen fields not required
+    expected: valid
+  - file: data/PlateBasedReporterAssayTemplate/invalid_experimentaldata_missing_compound.json
+    description: experimentalData still requires compoundName/compoundDose/compoundDoseUnit
+    expected: invalid
+    reason: resourceType is experimentalData but compound* fields missing


### PR DESCRIPTION
## Summary

Implements relaxed conditional validation for co-located auxiliary files (`manifest.csv`, `.log`, `.out`, `.sh`, etc.) as proposed in #825, keyed on `resourceType`. LinkML compiles the rules to JSON-Schema `allOf`/`if-then`, so **no change to `utils/gen-json-schema-class.py`** is required (per @anngvu's guidance on the issue).

### Behavior
- **experimentalData** (the default) → full template requirements, unchanged.
- **manifest, metadata, report, workflow report, tool, result, weblink, protocol** → relaxed: only `fileFormat` + `resourceType` required.

This lets auxiliary files dropped in a dataset folder validate cleanly instead of erroring on experimental annotations (`assay`, `platform`, `specimenID`, …) that don't apply to them.

### How it works
Experimental-annotation slots are set `required: false` and **re-required only when `resourceType == experimentalData`** via LinkML `rules`. Each rule lives on the class that *introduces* the slot, so each generated schema's `then.required` contains only fields that class actually defines (no spurious requirements that would break valid experimentalData files). `fileFormat` and `resourceType` stay unconditionally required.

Rules added on the abstract bases (`BiologicalAssayDataTemplate`, `NonBiologicalAssayDataTemplate`, `GeneticsAssayTemplate`, `ProteinAssayTemplate`, `ImagingAssayTemplate`) cover most templates via inheritance; per-template introduced requirements (`library*`, `channel`, `dataCollectionMode`, `genomicReference`, `expressionUnit`, `targetCaptureKitID`, `compound*`, `specimenID`, `epidemiologyMetric`) are relaxed in place.

### Example (BulkSequencingAssayTemplate)
```
top-level required: [fileFormat, resourceType]
allOf:
  if resourceType == experimentalData -> then.required:
     [dataType, dataSubtype, assay, individualID, species, diagnosis, tumorType,
      specimenID, platform, specimenPreparationMethod, libraryStrand, libraryPreparationMethod]
```

## Test plan
- [x] `make -B && python utils/gen-json-schema-class.py` regenerates; verified each file template's `(top-level required ∪ experimentalData then.required)` matches the pre-change required set (diffed against a baseline oracle).
- [x] New `tests/test_registry_resourcetype_relaxed.yaml` (ProcessedAggregated, WGS, MaterialScience, PlateBasedReporter): auxiliary files **valid**; experimentalData-missing-fields and missing `fileFormat`/`resourceType` **invalid**.
- [x] `pytest tests/test_schema_instances.py tests/test_template_datatypes.py tests/test_model_system_sync.py` → all pass (no regressions).
- Artifacts (`dist/`, `registered-json-schemas/`) intentionally not committed — rebuilt by CI and the on-main rebuild workflow (consistent with #901).

## Notes / known nuances
- **PlateBasedReporterAssayTemplate**: `platform` stays optional (preserves the #901 relaxation); `individualID` becomes required for `experimentalData`.
- A few generic FileBased-direct templates (`GenericDataResourceTemplate`, `AnalysisResultTemplate`, `ReferenceSequenceTemplate`, `EpidemiologyDataTemplate`) relax `dataType`/`dataSubtype` fully — LinkML does not emit the re-require conditional when the class also sets `resourceType: ifabsent`. Auxiliary files still validate; experimentalData strictness is slightly looser for these niche templates.
- Pairs with #913 (adds `log`/`out`/`sh` fileFormat values for the same auxiliary files).

Closes #825.