### PR TITLE
Map bone histomorphometry and focus forming assay to ontology terms

### DIFF
--- a/modules/Assay/Assay.yaml
+++ b/modules/Assay/Assay.yaml
@@ -73,6 +73,8 @@ enums:
         description: Blue native PAGE (BN-PAGE) permits a high-resolution separation of multi-protein complexes under native conditions.
         meaning: MI:0276
       bone histomorphometry:
+        source: http://snomed.info/id/84675000
+        meaning: SNOMED:84675000
         description: Asasy providing quantitative information on metabolic bone diseases and fracture healing. This is the broader assay concept containing both static and dynamic histomorphometry.
       cAMP-Glo Max Assay:
         description: The cAMP-Glo Max Assay from Promega is a bioluminescent assay used for the quantification of cyclic AMP (cAMP) in cell-based assays. It utilizes a luminescent luciferase-based detection system to detect the levels of cAMP in cell lysates, which can be used to study G protein-coupled receptor (GPCR) signaling and other intracellular signaling pathways.
@@ -152,6 +154,8 @@ enums:
         description: A cytometry assay in which an input cell population is put in solution, is passed by a laser, and optical sensors are used to detect scattering of the laser light and/or fluorescence of specific markers to count and characterize the particles in solution
         meaning: OBI:0000916
       focus forming assay:
+        source: http://purl.obolibrary.org/obo/NCIT_C202399
+        meaning: NCIT:C202399
         description: The focus forming assay (FFA) is an immunostaining technique and a variation of the viral plaque assay. Instead of detecting the plaque formation after virus-induced cell lysis these assays detect infected host cells and infectious virus particles before a plaque is formed.
         see_also:
         - https://www.bpes.co.uk/focus-forming-assay-virus-titer-quantitation/


### PR DESCRIPTION
Adds ontology mappings to two CellBasedAssayEnum values via the visual editor:
- bone histomorphometry → SNOMED:84675000
- focus forming assay → NCIT:C202399