### PR TITLE
Validate migration of and remove schematic annotations for deps, validation rules

### DIFF
--- a/modules/Template/Biosample.yaml
+++ b/modules/Template/Biosample.yaml
@@ -5,10 +5,8 @@ classes:
       requiresComponent: ''
       templateUsage: most_common
       dataGranularity: individual-level
-    description: 'Template for non-human individual-level data. For xenografts, individualID
-      references the cell line donor. Use sex/age/species for the individual animal.
-      Use modelSystemName for the animal model genetic background, with modelSpecies/modelSex/modelAge
-      for the model host animal.'
+    description: 'Template for non-human individual-level data. Use sex/age/species
+      for the individual animal, and modelSystemName for the name of the mouse model.'
     slots:
     - individualID
     - sex
@@ -23,10 +21,6 @@ classes:
     - germlineMutation
     - species
     - modelSystemName
-    - modelSpecies
-    - modelSex
-    - modelAge
-    - modelAgeUnit
   BiospecimenTemplate:
     annotations:
       required: false

--- a/modules/Template/Biosample.yaml
+++ b/modules/Template/Biosample.yaml
@@ -46,6 +46,16 @@ classes:
     - modelSex
     - modelAge
     - modelAgeUnit
+    rules:
+    - description: If modelAge is provided, modelAgeUnit must be provided
+      preconditions:
+        slot_conditions:
+          modelAge:
+            value_presence: PRESENT
+      postconditions:
+        slot_conditions:
+          modelAgeUnit:
+            value_presence: PRESENT
   HumanCohortTemplate:
     annotations:
       required: false

--- a/modules/Template/Biosample.yaml
+++ b/modules/Template/Biosample.yaml
@@ -27,6 +27,16 @@ classes:
     - modelSex
     - modelAge
     - modelAgeUnit
+    rules:
+    - description: If modelAge is provided, modelAgeUnit must be provided
+      preconditions:
+        slot_conditions:
+          modelAge:
+            value_presence: PRESENT
+      postconditions:
+        slot_conditions:
+          modelAgeUnit:
+            value_presence: PRESENT
   BiospecimenTemplate:
     annotations:
       required: false
@@ -52,6 +62,16 @@ classes:
     - modelSex
     - modelAge
     - modelAgeUnit
+    rules:
+    - description: If modelAge is provided, modelAgeUnit must be provided
+      preconditions:
+        slot_conditions:
+          modelAge:
+            value_presence: PRESENT
+      postconditions:
+        slot_conditions:
+          modelAgeUnit:
+            value_presence: PRESENT
   HumanCohortTemplate:
     annotations:
       required: false

--- a/modules/Template/Biosample.yaml
+++ b/modules/Template/Biosample.yaml
@@ -27,16 +27,6 @@ classes:
     - modelSex
     - modelAge
     - modelAgeUnit
-    rules:
-    - description: If modelAge is provided, modelAgeUnit must be provided
-      preconditions:
-        slot_conditions:
-          modelAge:
-            value_presence: PRESENT
-      postconditions:
-        slot_conditions:
-          modelAgeUnit:
-            value_presence: PRESENT
   BiospecimenTemplate:
     annotations:
       required: false
@@ -62,16 +52,6 @@ classes:
     - modelSex
     - modelAge
     - modelAgeUnit
-    rules:
-    - description: If modelAge is provided, modelAgeUnit must be provided
-      preconditions:
-        slot_conditions:
-          modelAge:
-            value_presence: PRESENT
-      postconditions:
-        slot_conditions:
-          modelAgeUnit:
-            value_presence: PRESENT
   HumanCohortTemplate:
     annotations:
       required: false

--- a/modules/Template/Data_Genomics.yaml
+++ b/modules/Template/Data_Genomics.yaml
@@ -279,6 +279,15 @@ classes:
       fileFormat:
         range: SequencingFileFormatEnum
     rules:
+    - description: If modelAge is provided, modelAgeUnit must be provided
+      preconditions:
+        slot_conditions:
+          modelAge:
+            value_presence: PRESENT
+      postconditions:
+        slot_conditions:
+          modelAgeUnit:
+            value_presence: PRESENT
     - description: If experimentalTimepoint is provided, timepointUnit must be provided
       preconditions:
         slot_conditions:
@@ -615,6 +624,25 @@ classes:
         range: SequencingPlatformEnum
       fileFormat:
         range: SequencingFileFormatEnum
+    rules:
+    - description: If genePerturbed is provided, genePerturbationType must be provided
+      preconditions:
+        slot_conditions:
+          genePerturbed:
+            value_presence: PRESENT
+      postconditions:
+        slot_conditions:
+          genePerturbationType:
+            value_presence: PRESENT
+    - description: If genePerturbed is provided, genePerturbationTechnology must be provided
+      preconditions:
+        slot_conditions:
+          genePerturbed:
+            value_presence: PRESENT
+      postconditions:
+        slot_conditions:
+          genePerturbationTechnology:
+            value_presence: PRESENT
 
   MethylationArrayTemplate:
     annotations:

--- a/modules/Template/Data_Genomics.yaml
+++ b/modules/Template/Data_Genomics.yaml
@@ -279,6 +279,15 @@ classes:
       fileFormat:
         range: SequencingFileFormatEnum
     rules:
+    - description: If modelAge is provided, modelAgeUnit must be provided
+      preconditions:
+        slot_conditions:
+          modelAge:
+            value_presence: PRESENT
+      postconditions:
+        slot_conditions:
+          modelAgeUnit:
+            value_presence: PRESENT
     - description: If experimentalTimepoint is provided, timepointUnit must be provided
       preconditions:
         slot_conditions:

--- a/modules/Template/Data_Genomics.yaml
+++ b/modules/Template/Data_Genomics.yaml
@@ -279,15 +279,6 @@ classes:
       fileFormat:
         range: SequencingFileFormatEnum
     rules:
-    - description: If modelAge is provided, modelAgeUnit must be provided
-      preconditions:
-        slot_conditions:
-          modelAge:
-            value_presence: PRESENT
-      postconditions:
-        slot_conditions:
-          modelAgeUnit:
-            value_presence: PRESENT
     - description: If experimentalTimepoint is provided, timepointUnit must be provided
       preconditions:
         slot_conditions:

--- a/modules/Template/Data_Misc.yaml
+++ b/modules/Template/Data_Misc.yaml
@@ -30,6 +30,15 @@ classes:
       assay:
         required: false
     rules:
+    - description: If dataType is provided, dataSubtype must be provided
+      preconditions:
+        slot_conditions:
+          dataType:
+            value_presence: PRESENT
+      postconditions:
+        slot_conditions:
+          dataSubtype:
+            value_presence: PRESENT
     - description: 'Relaxed conditional validation (issue #825): the listed fields
         are required only for experimentalData. Auxiliary co-located files (manifest,
         metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'
@@ -118,6 +127,15 @@ classes:
       dataSubtype:
         required: false
     rules:
+    - description: If dataType is provided, dataSubtype must be provided
+      preconditions:
+        slot_conditions:
+          dataType:
+            value_presence: PRESENT
+      postconditions:
+        slot_conditions:
+          dataSubtype:
+            value_presence: PRESENT
     - description: 'Relaxed conditional validation (issue #825): the listed fields
         are required only for experimentalData. Auxiliary co-located files (manifest,
         metadata, report, workflow report, tool, result, weblink, protocol) are exempt.'

--- a/modules/props.yaml
+++ b/modules/props.yaml
@@ -61,8 +61,6 @@ slots:
     title: Acknowledgement Statements
     required: false
   age:
-    annotations:
-      requiresDependency: ageUnit
     description: >-
       Age of the individual. Use with `ageUnit`. IMPORTANT: For human data,
       HIPAA requires masking ages >= 90; use the `AgeMask` value ">= 90"
@@ -83,8 +81,6 @@ slots:
     title: Age Group
     required: false
   aliquotID:
-    annotations:
-      requiresDependency: specimenID
     description: A unique identifier (non-PII) that represents the aliquots used for e.g. replicate runs. This is linked to the specimenID.
     title: Aliquot ID
     required: false
@@ -205,8 +201,6 @@ slots:
     title: Cell ID
     required: false
   cellType:
-    annotations:
-      validationRules: list like
     description: A cell type is a distinct morphological or functional form of cell.
     range: Cell
     multivalued: true
@@ -250,8 +244,6 @@ slots:
     required: false
     title: Comments
   compoundDose:
-    annotations:
-      requiresDependency: compoundDoseUnit
     description: A dose quantity for the treatment compound. To be used with compoundDoseUnit.
     title: Compound Dose
     required: false
@@ -264,9 +256,6 @@ slots:
     title: Compound Name
     required: false
   concentrationMaterial:
-    annotations:
-      requiresDependency: concentrationMaterialUnit
-      validationRules: num
     description: Numeric value for concentration of the material
     range: float
     title: Concentration Material
@@ -277,8 +266,6 @@ slots:
     title: Concentration Material Unit
     required: false
   concentrationNaCl:
-    annotations:
-      requiresDependency: concentrationNaClUnit
     description: Numeric value for NaCl concentration
     title: Concentration Na Cl
     required: false
@@ -376,8 +363,6 @@ slots:
     title: Data Subtype
     required: true
   dataType:
-    annotations:
-      requiresDependency: dataSubtype
     any_of:
     - range: Data
     - range: MetadataEnum
@@ -494,9 +479,6 @@ slots:
     title: Experimental Factor
     required: false
   experimentalTimepoint:
-    annotations:
-      requiresDependency: timepointUnit
-      validationRules: num
     description: The numeric value indicating the time elapsed from the beginning of the experiment at which the specimen was collected. Use in tandem with timePointUnit
     range: float
     title: Experimental Timepoint
@@ -558,14 +540,10 @@ slots:
     title: Gene Perturbation Type
     required: false
   genePerturbed:
-    annotations:
-      requiresDependency: genePerturbationType,genePerturbationTechnology
     description: The HUGO gene symbol for the gene that is perturbed.
     title: Gene Perturbed
     required: false
   genomicReference:
-    annotations:
-      requiresDependency: genomicReferenceLink
     description: Version of genome reference used for alignment in processing workflow
     range: GenomicReferenceEnum
     notes:
@@ -643,8 +621,6 @@ slots:
     title: Immersion
     required: false
   individualID:
-    annotations:
-      validationRules: list like
     description: A unique identifier (non-PII) that represents the individual from which the data came. This could be a patient or animal ID.
     multivalued: true
     title: Individual ID
@@ -792,8 +768,6 @@ slots:
     required: false
     title: Learning disability
   lensAperture:
-    annotations:
-      validationRules: num
     description: Numerical aperture of the lens. Floating point value > 0.
     range: float
     title: Lens Aperture
@@ -824,8 +798,6 @@ slots:
     title: Library Preparation Method
     required: true
   libraryPCRCycles:
-    annotations:
-      validationRules: int
     description: The number of PCR cycles used during the construction of a sequencing library. Important for genomics data generated from cell-free DNA.
     range: integer
     required: false
@@ -879,8 +851,6 @@ slots:
     required: false
     title: Meningioma
   modelSystemName:
-    annotations:
-      validationRules: list like
     any_of:
     - range: CellLineModel
     - range: CellLineModelManual
@@ -902,15 +872,10 @@ slots:
     description: Sex of the individual animal model used in the experiment. Distinct from donor sex.
     required: false
   modelAge:
-    annotations:
-      requiresDependency: modelAgeUnit
-      validationRules: num
     description: Age of the individual animal model at time of experiment. Distinct from donor age. Use with modelAgeUnit.
     range: float
     required: false
   modelAgeUnit:
-    annotations:
-      requiresDependency: modelAge
     description: Time unit for modelAge (e.g., weeks for mice). Required when modelAge is specified.
     range: TimeUnit
     required: false
@@ -963,8 +928,6 @@ slots:
     title: NF2 Genotype
     required: false
   nominalMagnification:
-    annotations:
-      validationRules: num
     description: magnification of the lens as specified by the manufacturer - i.e. '60' is a 60X lens.
     range: float
     title: Nominal Magnification
@@ -1014,8 +977,6 @@ slots:
     required: false
     title: Other tumors
   pH:
-    annotations:
-      validationRules: num
     description: Numeric value for pH (range 0-14)
     range: float
     title: pH
@@ -1025,8 +986,6 @@ slots:
     range: PainEnum
     title: Pain status
   pairsOnDifferentChr:
-    annotations:
-      validationRules: int
     description: Pairs on different chromosomes collected from samtools
     range: integer
     title: Pairs On Different Chr
@@ -1036,8 +995,6 @@ slots:
     title: Parent ID
     required: false
   parentSpecimenID:
-    annotations:
-      requiresDependency: specimenID
     description: 'A unique identifier (non-PII) that represents the parent specimen (sample) from which the data came from, e.g. the single parent tumor that was subsectioned into several samples.  The parentSpecimenID can be the same as specimenID when there is no subsectioning.
 
       '
@@ -1135,15 +1092,11 @@ slots:
     title: Progress Report Number
     required: false
   proportionCoverage10x:
-    annotations:
-      validationRules: num
     description: Proportion of all reference bases for whole genome sequencing, or targeted bases for whole exome and targeted sequencing, that achieves 10X or greater coverage from Picard Tools
     range: float
     title: Proportion Coverage 10x
     required: false
   proportionCoverage30x:
-    annotations:
-      validationRules: num
     description: Proportion of all reference bases for whole genome sequencing, or targeted bases for whole exome and targeted sequencing, that achieves 30X or greater coverage from Picard Tools
     range: float
     title: Proportion Coverage 30x
@@ -1199,22 +1152,16 @@ slots:
     required: false
     title: Radiation at any time
   readDepth:
-    annotations:
-      validationRules: int
     description: If available, the coverage statistic as output from bedtools coverage or samtools stats.
     range: integer
     title: Read Depth
     required: false
   readLength:
-    annotations:
-      validationRules: int
     description: Number of base pairs (bp) sequenced for a read
     range: integer
     title: Read Length
     required: false
   readPair:
-    annotations:
-      validationRules: inRange 1 2
     description: The read of origin, Read 1 or Read 2
     range: integer
     minimum_value: 1
@@ -1238,8 +1185,6 @@ slots:
     title: Reads Duplicated Percent
     required: false
   readsMappedPercent:
-    annotations:
-      validationRules: num
     description: Percent of mapped reads collected from samtools
     range: float
     title: Reads Mapped Percent
@@ -1481,8 +1426,6 @@ slots:
     required: true
     see_also: https://www.w3.org/TR/vocab-dcat-3/#Property:resource_title
   totalReads:
-    annotations:
-      validationRules: int
     description: If available, the total number of reads collected from samtools.
     range: integer
     title: Total Reads
@@ -1500,8 +1443,6 @@ slots:
     title: Transplantation Recipient Tissue
     required: false
   transplantationType:
-    annotations:
-      requiresDependency: transplantationRecipientSpecies,transplantationRecipientTissue
     description: Type of transplantation involved in the experiment, derived from MESH
     range: TransplantationType
     title: Transplantation Type
@@ -1552,8 +1493,6 @@ slots:
     range: VitalStatusEnum
     title: Vital status
   workflow:
-    annotations:
-      requiresDependency: workflowLink
     description: Name and version of the workflow used to generate/analyze the data
     range: WorkflowEnum
     title: Workflow
@@ -1563,9 +1502,6 @@ slots:
     title: Workflow Link
     required: false
   workingDistance:
-    annotations:
-      requiresDependency: workingDistanceUnit
-      validationRules: num
     description: Working distance of the lens expressed as a floating point number > 0.
     range: float
     title: Working Distance
@@ -1576,8 +1512,6 @@ slots:
     title: Working Distance Unit
     required: false
   yearProcessed:
-    annotations:
-      validationRules: int
     description: "Year in which the resource was processed/derived, if applicable.  This is only required for data processed by NF-OSI for tracking purposes, optional for community-contributed datasets. \n"
     in_subset:
     - portal
@@ -1587,8 +1521,6 @@ slots:
     title: Year Processed
     required: false
   yearPublished:
-    annotations:
-      validationRules: int
     description: Year in which the resource was published/generally made available.
     in_subset:
     - portal

--- a/tests/data/AnalysisResultTemplate/invalid_datatype_missing_subtype.json
+++ b/tests/data/AnalysisResultTemplate/invalid_datatype_missing_subtype.json
@@ -1,0 +1,5 @@
+{
+  "fileFormat": "csv",
+  "resourceType": "metadata",
+  "dataType": "clinical"
+}

--- a/tests/data/AnalysisResultTemplate/valid_datatype_with_subtype.json
+++ b/tests/data/AnalysisResultTemplate/valid_datatype_with_subtype.json
@@ -1,0 +1,6 @@
+{
+  "fileFormat": "csv",
+  "resourceType": "metadata",
+  "dataType": "clinical",
+  "dataSubtype": "processed"
+}

--- a/tests/data/BiospecimenTemplate/invalid_modelage_missing_unit.json
+++ b/tests/data/BiospecimenTemplate/invalid_modelage_missing_unit.json
@@ -1,0 +1,6 @@
+{
+  "individualID": ["NF-M-001"],
+  "specimenID": "NF-M-001-T1",
+  "tumorType": "Plexiform Neurofibroma",
+  "modelAge": 8
+}

--- a/tests/data/BiospecimenTemplate/valid_modelage_with_unit.json
+++ b/tests/data/BiospecimenTemplate/valid_modelage_with_unit.json
@@ -1,0 +1,7 @@
+{
+  "individualID": ["NF-M-001"],
+  "specimenID": "NF-M-001-T1",
+  "tumorType": "Plexiform Neurofibroma",
+  "modelAge": 8,
+  "modelAgeUnit": "weeks"
+}

--- a/tests/data/ChIPSeqTemplate/invalid_geneperturbed_missing_qualifiers.json
+++ b/tests/data/ChIPSeqTemplate/invalid_geneperturbed_missing_qualifiers.json
@@ -1,0 +1,5 @@
+{
+  "fileFormat": "bed",
+  "resourceType": "metadata",
+  "genePerturbed": "NF1"
+}

--- a/tests/data/ChIPSeqTemplate/invalid_geneperturbed_missing_technology.json
+++ b/tests/data/ChIPSeqTemplate/invalid_geneperturbed_missing_technology.json
@@ -1,0 +1,6 @@
+{
+  "fileFormat": "bed",
+  "resourceType": "metadata",
+  "genePerturbed": "NF1",
+  "genePerturbationType": "CRISPR"
+}

--- a/tests/data/ChIPSeqTemplate/valid_geneperturbed_complete.json
+++ b/tests/data/ChIPSeqTemplate/valid_geneperturbed_complete.json
@@ -1,0 +1,7 @@
+{
+  "fileFormat": "bed",
+  "resourceType": "metadata",
+  "genePerturbed": "NF1",
+  "genePerturbationType": "CRISPR",
+  "genePerturbationTechnology": "CRISPR"
+}

--- a/tests/data/ChIPSeqTemplate/valid_no_geneperturbation.json
+++ b/tests/data/ChIPSeqTemplate/valid_no_geneperturbation.json
@@ -1,0 +1,4 @@
+{
+  "fileFormat": "bed",
+  "resourceType": "metadata"
+}

--- a/tests/data/GenericDataResourceTemplate/invalid_datatype_missing_subtype.json
+++ b/tests/data/GenericDataResourceTemplate/invalid_datatype_missing_subtype.json
@@ -1,0 +1,5 @@
+{
+  "fileFormat": "csv",
+  "resourceType": "metadata",
+  "dataType": "clinical"
+}

--- a/tests/data/GenericDataResourceTemplate/valid_datatype_with_subtype.json
+++ b/tests/data/GenericDataResourceTemplate/valid_datatype_with_subtype.json
@@ -1,0 +1,6 @@
+{
+  "fileFormat": "csv",
+  "resourceType": "metadata",
+  "dataType": "clinical",
+  "dataSubtype": "processed"
+}

--- a/tests/data/PdxGenomicsAssayTemplate/invalid_modelage_missing_unit.json
+++ b/tests/data/PdxGenomicsAssayTemplate/invalid_modelage_missing_unit.json
@@ -1,0 +1,5 @@
+{
+  "fileFormat": "fastq",
+  "resourceType": "metadata",
+  "modelAge": 8
+}

--- a/tests/data/PdxGenomicsAssayTemplate/valid_modelage_with_unit.json
+++ b/tests/data/PdxGenomicsAssayTemplate/valid_modelage_with_unit.json
@@ -1,0 +1,6 @@
+{
+  "fileFormat": "fastq",
+  "resourceType": "metadata",
+  "modelAge": 8,
+  "modelAgeUnit": "weeks"
+}

--- a/tests/test_registry_datatype_dependency.yaml
+++ b/tests/test_registry_datatype_dependency.yaml
@@ -1,0 +1,32 @@
+# Conditional (if-then) Dependency Validation: dataType -> dataSubtype
+#
+# Migrated from the legacy schematic annotation on the `dataType` slot:
+#   requiresDependency: dataSubtype
+#
+# BiologicalAssayDataTemplate / NonBiologicalAssayDataTemplate already carry
+# this rule (inherited by their subclasses). AnalysisResultTemplate and
+# GenericDataResourceTemplate descend directly from FileBasedTemplate, so they
+# did NOT inherit it despite offering both slots — the rule is added directly.
+#
+# resourceType is "metadata" so no other conditional requirements interfere;
+# these cases isolate the dataType -> dataSubtype dependency.
+---
+schema: AnalysisResultTemplate
+instances:
+  - file: data/AnalysisResultTemplate/valid_datatype_with_subtype.json
+    description: dataType and dataSubtype both provided — satisfies the conditional dependency
+    expected: valid
+  - file: data/AnalysisResultTemplate/invalid_datatype_missing_subtype.json
+    description: dataType is present but dataSubtype is absent
+    expected: invalid
+    reason: dataType is present but dataSubtype is missing
+---
+schema: GenericDataResourceTemplate
+instances:
+  - file: data/GenericDataResourceTemplate/valid_datatype_with_subtype.json
+    description: dataType and dataSubtype both provided — satisfies the conditional dependency
+    expected: valid
+  - file: data/GenericDataResourceTemplate/invalid_datatype_missing_subtype.json
+    description: dataType is present but dataSubtype is absent
+    expected: invalid
+    reason: dataType is present but dataSubtype is missing

--- a/tests/test_registry_geneperturbed.yaml
+++ b/tests/test_registry_geneperturbed.yaml
@@ -1,0 +1,32 @@
+# Conditional (if-then) Dependency Validation: genePerturbed
+#
+# Migrated from the legacy schematic annotation on the `genePerturbed` slot:
+#   requiresDependency: genePerturbationType,genePerturbationTechnology
+#
+# The LinkML `rules` on ChIPSeqTemplate express this as two allOf if-then
+# conditions (one per qualifier), which gen-json-schema materializes as:
+#   if genePerturbed is present -> genePerturbationType is required
+#   if genePerturbed is present -> genePerturbationTechnology is required
+#
+# resourceType is "metadata" (not "experimentalData") so the #825 relaxed
+# requirements do not apply and these cases isolate the genePerturbed rule.
+
+schema: ChIPSeqTemplate
+instances:
+  - file: data/ChIPSeqTemplate/valid_geneperturbed_complete.json
+    description: genePerturbed provided together with both genePerturbationType and genePerturbationTechnology — satisfies both conditional dependencies
+    expected: valid
+
+  - file: data/ChIPSeqTemplate/valid_no_geneperturbation.json
+    description: genePerturbed absent, so neither qualifier is required — the rule is not triggered
+    expected: valid
+
+  - file: data/ChIPSeqTemplate/invalid_geneperturbed_missing_qualifiers.json
+    description: genePerturbed present but both genePerturbationType and genePerturbationTechnology are missing
+    expected: invalid
+    reason: genePerturbed is present but genePerturbationType/genePerturbationTechnology are missing
+
+  - file: data/ChIPSeqTemplate/invalid_geneperturbed_missing_technology.json
+    description: genePerturbed and genePerturbationType present, but genePerturbationTechnology is missing
+    expected: invalid
+    reason: genePerturbed is present but genePerturbationTechnology is missing

--- a/tests/test_registry_modelage_dependency.yaml
+++ b/tests/test_registry_modelage_dependency.yaml
@@ -1,0 +1,32 @@
+# Conditional (if-then) Dependency Validation: modelAge -> modelAgeUnit
+#
+# Migrated from the legacy schematic annotation on the `modelAge` slot:
+#   requiresDependency: modelAgeUnit
+#
+# This is the animal-model analog of age -> ageUnit. The modelAge / modelAgeUnit
+# slots are exposed by BiospecimenTemplate and PdxGenomicsAssayTemplate, so the
+# rule is added to those. (modelAge is numeric, so there is no "Unknown"
+# exception like age has.)
+#
+# For PdxGenomicsAssayTemplate, resourceType is "metadata" so the #825 relaxed
+# experimentalData requirements do not interfere and the case isolates this rule.
+---
+schema: BiospecimenTemplate
+instances:
+  - file: data/BiospecimenTemplate/valid_modelage_with_unit.json
+    description: modelAge and modelAgeUnit both provided — satisfies the conditional dependency
+    expected: valid
+  - file: data/BiospecimenTemplate/invalid_modelage_missing_unit.json
+    description: modelAge is present but modelAgeUnit is absent
+    expected: invalid
+    reason: modelAge is present but modelAgeUnit is missing
+---
+schema: PdxGenomicsAssayTemplate
+instances:
+  - file: data/PdxGenomicsAssayTemplate/valid_modelage_with_unit.json
+    description: modelAge and modelAgeUnit both provided — satisfies the conditional dependency
+    expected: valid
+  - file: data/PdxGenomicsAssayTemplate/invalid_modelage_missing_unit.json
+    description: modelAge is present but modelAgeUnit is absent
+    expected: invalid
+    reason: modelAge is present but modelAgeUnit is missing


### PR DESCRIPTION
Close #929. An earlier migration deferred removing schematic notations in the data model, which this now removes and finalizes transition with schematic backward-compatibility. Before removing the annotations, validate that valuable schematic dep/validation rules have been re-implemented in LinkML. Found and fixed only one place where `genePerturbed` dep rule was not implemented. Add tests.

Update: Add a fix for #935