### PR TITLE
feat: declare unique_keys on record-based templates and enforce via upsert keys (#931)

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Run pytest
         id: pytest
         run: |
-          pytest tests/test_schema_instances.py tests/test_template_datatypes.py tests/test_model_system_sync.py -v \
+          pytest tests/test_schema_instances.py tests/test_template_datatypes.py tests/test_model_system_sync.py tests/test_recordset_upsert_keys.py -v \
             --tb=short 2>&1 | tee pytest_output.txt
           echo "exit_code=${PIPESTATUS[0]}" >> $GITHUB_OUTPUT
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -282,7 +282,7 @@ SYNAPSE_AUTH_TOKEN="$TOKEN" python utils/create_recordset_task.py \
 | `--template` | Template name or schema URI (required) | - |
 | `--description` | RecordSet description | Auto-generated |
 | `--task-name` | Curation task name | Auto-generated |
-| `--upsert-keys` | Fields that uniquely identify records | None |
+| `--upsert-keys` | Fields that uniquely identify records | Derived from the template's `unique_keys`, else `None` |
 | `--instructions` | Instructions for contributors | "Please add metadata records" |
 | `--bind-schema` / `--no-bind-schema` | Bind schema to RecordSet | True |
 | `--output-format` | `json` or `github` | `json` |
@@ -292,6 +292,10 @@ SYNAPSE_AUTH_TOKEN="$TOKEN" python utils/create_recordset_task.py \
 **Notes:**
 - **Project ID** is automatically derived from the folder
 - **Upsert keys:** Specify field names that uniquely identify each record. This enables updates to existing records rather than creating duplicates. Common choices: `study`, `name`, `individualID`, etc.
+- **Natural keys and `unique_keys`:** Record-based templates can declare their natural key with LinkML [`unique_keys`](https://linkml.io/linkml/schemas/constraints.html) (e.g. `BiospecimenTemplate` keys on `individualID` + `specimenID`).
+  Note that `unique_keys` is **not** expressed in the generated JSON Schema, so the Synapse JSON-Schema consumer does not enforce it - it only enforces standard keywords (`required`, `enum`, `if/then`).
+  Record uniqueness is instead enforced at bind time via the RecordSet upsert keys above.
+  When `--upsert-keys` is omitted, `create_recordset_task.py` derives them from the template's `unique_keys`, so the declared natural key drives real enforcement.
 
 ---
 

--- a/modules/Template/Biosample.yaml
+++ b/modules/Template/Biosample.yaml
@@ -27,6 +27,12 @@ classes:
     - modelSex
     - modelAge
     - modelAgeUnit
+    unique_keys:
+      individual_natural_key:
+        description: Each record describes a distinct individual, so individualID
+          uniquely identifies a row.
+        unique_key_slots:
+        - individualID
   BiospecimenTemplate:
     annotations:
       required: false
@@ -52,6 +58,13 @@ classes:
     - modelSex
     - modelAge
     - modelAgeUnit
+    unique_keys:
+      specimen_natural_key:
+        description: Each record describes a distinct specimen; specimenID together
+          with individualID uniquely identifies a row.
+        unique_key_slots:
+        - individualID
+        - specimenID
   HumanCohortTemplate:
     annotations:
       required: false
@@ -128,6 +141,12 @@ classes:
     - lenticularOpacity
     - nonvestibularSchwannomas
     - numberOfSchwannomas
+    unique_keys:
+      individual_natural_key:
+        description: Each record describes a distinct individual, so individualID
+          uniquely identifies a row.
+        unique_key_slots:
+        - individualID
     slot_usage:
       species:
         ifabsent: string(Homo sapiens)

--- a/tests/test_recordset_upsert_keys.py
+++ b/tests/test_recordset_upsert_keys.py
@@ -1,0 +1,112 @@
+"""Tests for deriving RecordSet upsert keys from LinkML ``unique_keys``.
+
+LinkML ``unique_keys`` declare a template's natural key but are not expressed in
+the generated JSON Schema, so the Synapse JSON-Schema consumer does not enforce
+them. Record uniqueness is instead enforced through RecordSet upsert keys.
+``derive_upsert_keys`` bridges the two; these tests pin that behavior and guard
+the ``unique_keys`` declarations on the record-based Biosample templates.
+"""
+
+import sys
+import textwrap
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "utils"))
+
+from create_recordset_task import derive_upsert_keys  # noqa: E402
+
+
+def _write_model(tmp_path, body: str) -> str:
+    model_file = tmp_path / "model.yaml"
+    model_file.write_text(textwrap.dedent(body))
+    return str(model_file)
+
+
+def test_derive_compound_unique_key(tmp_path):
+    model = _write_model(tmp_path, """
+        classes:
+          BiospecimenTemplate:
+            unique_keys:
+              specimen_natural_key:
+                unique_key_slots:
+                - individualID
+                - specimenID
+    """)
+    assert derive_upsert_keys("BiospecimenTemplate", model) == [
+        "individualID",
+        "specimenID",
+    ]
+
+
+def test_derive_single_unique_key(tmp_path):
+    model = _write_model(tmp_path, """
+        classes:
+          AnimalIndividualTemplate:
+            unique_keys:
+              individual_natural_key:
+                unique_key_slots:
+                - individualID
+    """)
+    assert derive_upsert_keys("AnimalIndividualTemplate", model) == ["individualID"]
+
+
+def test_no_unique_keys_returns_none(tmp_path):
+    model = _write_model(tmp_path, """
+        classes:
+          SomeTemplate:
+            slots:
+            - specimenID
+    """)
+    assert derive_upsert_keys("SomeTemplate", model) is None
+
+
+def test_unknown_template_returns_none(tmp_path):
+    model = _write_model(tmp_path, """
+        classes:
+          SomeTemplate:
+            unique_keys:
+              k:
+                unique_key_slots:
+                - specimenID
+    """)
+    assert derive_upsert_keys("DoesNotExist", model) is None
+
+
+def test_unique_key_inherited_via_is_a(tmp_path):
+    model = _write_model(tmp_path, """
+        classes:
+          BaseRecord:
+            unique_keys:
+              natural_key:
+                unique_key_slots:
+                - individualID
+          ChildRecord:
+            is_a: BaseRecord
+    """)
+    assert derive_upsert_keys("ChildRecord", model) == ["individualID"]
+
+
+def test_missing_model_file_returns_none(tmp_path):
+    assert derive_upsert_keys("Whatever", str(tmp_path / "nope.yaml")) is None
+
+
+# --- Guard the actual source declarations on the Biosample record templates ---
+
+EXPECTED_BIOSAMPLE_UNIQUE_KEYS = {
+    "AnimalIndividualTemplate": ["individualID"],
+    "BiospecimenTemplate": ["individualID", "specimenID"],
+    "HumanCohortTemplate": ["individualID"],
+}
+
+
+def test_biosample_templates_declare_expected_unique_keys():
+    source = REPO_ROOT / "modules" / "Template" / "Biosample.yaml"
+    classes = yaml.safe_load(source.read_text())["classes"]
+    for template, expected_slots in EXPECTED_BIOSAMPLE_UNIQUE_KEYS.items():
+        unique_keys = classes[template].get("unique_keys")
+        assert unique_keys, f"{template} should declare unique_keys"
+        first = next(iter(unique_keys.values()))
+        assert first["unique_key_slots"] == expected_slots

--- a/utils/create_recordset_task.py
+++ b/utils/create_recordset_task.py
@@ -65,6 +65,59 @@ def load_schema_uri(template_name_or_uri: str, schema_dir: str = "registered-jso
     return schema_id
 
 
+def derive_upsert_keys(template_name: str, model_path: str = None) -> list:
+    """
+    Derive record-uniqueness upsert keys from a template's LinkML ``unique_keys``.
+
+    LinkML ``unique_keys`` declare a template's natural key (e.g. specimenID +
+    individualID), but they are not expressed in the generated JSON Schema and
+    are therefore not enforced by the Synapse JSON-Schema consumer. Synapse
+    enforces record uniqueness through RecordSet upsert keys instead, so this
+    function bridges the two: it reads the merged model, finds the class for
+    ``template_name`` (walking ``is_a`` ancestry), and returns the slot names of
+    its first declared ``unique_keys`` entry.
+
+    Args:
+        template_name: LinkML class/template name (not a full schema URI).
+        model_path: Path to the merged model YAML. Defaults to ``dist/NF.yaml``.
+
+    Returns:
+        List of slot names to use as upsert keys, or ``None`` when the template
+        declares no ``unique_keys`` (so callers fall back to the default).
+    """
+    try:
+        import yaml
+    except ImportError:
+        return None
+
+    if model_path is None:
+        model_path = Path(__file__).parent.parent / "dist" / "NF.yaml"
+
+    try:
+        with open(model_path, 'r') as f:
+            model = yaml.safe_load(f)
+    except (FileNotFoundError, OSError):
+        return None
+
+    classes = (model or {}).get("classes", {}) or {}
+    name = template_name
+    seen = set()
+    while name and name in classes and name not in seen:
+        seen.add(name)
+        cls = classes[name] or {}
+        unique_keys = cls.get("unique_keys")
+        if unique_keys:
+            # A class may declare several unique keys; use the first as the
+            # primary natural key. dict order follows YAML declaration order.
+            first = next(iter(unique_keys.values()))
+            slots = first.get("unique_key_slots") if isinstance(first, dict) else None
+            if slots:
+                return list(slots)
+        name = cls.get("is_a")
+
+    return None
+
+
 def create_recordset_task(
     folder_id: str,
     record_set_name: str,
@@ -137,6 +190,15 @@ def create_recordset_task(
     print(f"\nLoading schema: {template}")
     schema_uri = load_schema_uri(template)
     print(f"  Schema URI: {schema_uri}")
+
+    # If no explicit upsert keys were provided, derive them from the template's
+    # LinkML unique_keys so record uniqueness matches the schema's natural key.
+    # (unique_keys are not enforced by the JSON-Schema consumer; upsert keys are.)
+    if upsert_keys is None:
+        derived_keys = derive_upsert_keys(template)
+        if derived_keys:
+            upsert_keys = derived_keys
+            print(f"  Derived upsert keys from unique_keys: {upsert_keys}")
 
     # Set defaults
     if record_set_description is None:
@@ -280,7 +342,8 @@ Notes:
         '--upsert-keys',
         nargs='+',
         default=None,
-        help='Field names that uniquely identify records'
+        help='Field names that uniquely identify records. If omitted, derived '
+             "from the template's LinkML unique_keys when declared."
     )
 
     parser.add_argument(


### PR DESCRIPTION
## Summary

Addresses #931 (labels: `rfc`, `linkml-review`). Natural keys exist in the model (`specimenID`, `individualID`, `aliquotID`, `Component`) but no LinkML uniqueness constraint (`identifier` / `key` / `unique_keys`) was declared anywhere. This PR introduces uniqueness semantics where they are genuinely valid and wires them to the mechanism that actually enforces record uniqueness in Synapse.

**Opened as a draft** because one design question (multivalued `individualID`) is deferred to maintainer discussion - see Open questions below and the constraints comment on #931.

## What this changes

- **`modules/Template/Biosample.yaml`** - declare `unique_keys` on the three record-based templates where each row is one entity, so per-row uniqueness genuinely holds:
  - `AnimalIndividualTemplate` → `individualID`
  - `HumanCohortTemplate` → `individualID`
  - `BiospecimenTemplate` → compound `individualID` + `specimenID`
- **`utils/create_recordset_task.py`** - new `derive_upsert_keys()` that reads a template's `unique_keys` from the merged model and auto-populates the RecordSet `--upsert-keys` when they are not passed explicitly. This bridges the LinkML declaration to the mechanism Synapse actually uses to enforce record uniqueness.
- **`tests/test_recordset_upsert_keys.py`** - hermetic unit tests for the derivation (compound key, single key, `is_a` inheritance, missing/absent cases) plus a guard asserting the Biosample templates declare the expected keys. Wired into the CI pytest list in **`.github/workflows/main-ci.yml`**.
- **`DEVELOPMENT.md`** - documents the JSON-Schema gap and that upsert keys are the enforcement path.

Generated artifacts (`dist/`, `registered-json-schemas/`) are intentionally **not** committed - CI rebuilds them on `main`, `unique_keys` does not change the generated JSON schemas (verified), and committing locally would only add spurious diffs from a LinkML version mismatch (local 1.10 vs CI-pinned 1.8.1).

## Key finding (answers the "verify the Synapse JSON-Schema consumer honors these" note)

Verified empirically: LinkML `gen-json-schema` emits **no** JSON-Schema construct for `unique_keys`, and the Synapse JSON-Schema consumer (Schema Services API) has no cross-record uniqueness keyword (Draft-07 doesn't define one). `identifier`/`key` would only surface as `required`. So `unique_keys` is a **source-level/RDF** semantic; real record uniqueness is enforced via RecordSet **upsert keys**, which this PR now derives from `unique_keys`.

## Why not `identifier`/`key` on the slots, or the other listed natural keys

- `individualID` is `multivalued: true` → ineligible as a single-valued `identifier`/`key`.
- `Component` is constant across all rows of a manifest → a template discriminator, not a per-row key (and it is stripped from generated schemas).
- Setting `key`/`required` on the shared slots in `props.yaml` would force `required` across every template and conflict with the relaxed conditional validation from #825.
- File-based assay templates legitimately repeat a specimen across files/aliquots, so `unique_keys` there would be wrong - deliberately left untouched.

## Open questions (why draft)

- **Multivalued `individualID`:** because `individualID` is `multivalued: true`, using it as a unique/upsert key is fragile (Synapse compares key values to match rows for upsert; array comparison is order/overlap sensitive). Options for discussion: override to single-valued via `slot_usage: individualID: multivalued: false` on these record templates (semantically correct - one row = one individual; changes those schemas array→scalar), or accept the risk, or narrow the keys. Deferred to maintainers per the issue discussion.

## Test plan

- [x] `pytest tests/test_recordset_upsert_keys.py` (7 passed locally)
- [x] `pytest tests/test_schema_instances.py tests/test_template_datatypes.py tests/test_recordset_upsert_keys.py` (28 passed, 16 xfailed locally)
- [x] End-to-end: rebuilt the merged model and confirmed `derive_upsert_keys` returns `[individualID, specimenID]` for `BiospecimenTemplate`, `[individualID]` for the individual-level templates, and `None` for file-based assay templates
- [x] Verified `unique_keys` survives the `yq` merge into `dist/NF.yaml` and produces no construct in the generated JSON schema
- [ ] CI green after artifact rebuild on merge

Closes #931 pending resolution of the open question.
