### PR TITLE
Type slots that fall back to default `string` (#930, Phase 1)

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -245,6 +245,14 @@ jobs:
           message-id: pytest-report
           message-path: pytest_report.md
 
+      # `pytest | tee` makes the run step exit 0 even when tests fail, so the
+      # captured exit code has to be re-asserted after the report is posted.
+      - name: Fail if pytest failed
+        if: always() && steps.pytest.outputs.exit_code != '0'
+        run: |
+          echo "::error::pytest exited with ${{ steps.pytest.outputs.exit_code }} - see the pytest report comment on this PR."
+          exit 1
+
   check-schema-limits:
     name: Validate schema limits (Synapse platform)
     needs: [build]

--- a/modules/Assay/Parameter.yaml
+++ b/modules/Assay/Parameter.yaml
@@ -428,3 +428,59 @@ enums:
       micrometer:
       millimeter:
       nanometer:
+  CaptureAreaEnum:
+    description: Active region on a Visium/CytAssist slide where a tissue sample can be placed.
+    permissible_values:
+      A:
+      B:
+      C:
+      D:
+      A1:
+      B1:
+      C1:
+      D1:
+  DataCollectionModeEnum:
+    description: Mode of data collection in tandem MS assays.
+    permissible_values:
+      DDA:
+        description: Data-dependent acquisition.
+      DIA:
+        description: Data-independent acquisition.
+      Other:
+  ImmersionEnum:
+    description: Immersion medium of a microscope objective.
+    permissible_values:
+      air:
+      oil:
+      water:
+      other:
+  PeakCallingAlgorithmEnum:
+    description: Commonly used peak-calling algorithms for ChIP-Seq data analysis.
+    permissible_values:
+      MACS2:
+      SICER:
+      HOMER:
+      Genrich:
+      PeakRanger:
+      SEACR:
+      GEM:
+      MUSIC:
+      BroadPeak:
+      SWEMBL:
+      FSeq:
+      ZINBA:
+  RecordingSourceEnum:
+    description: Source of an electrophysiology recording.
+    permissible_values:
+      electrode:
+      tetrode:
+      shank:
+      Utah array:
+      other electrode array:
+  SlideVersionEnum:
+    description: Version of the imaging slide used; different versions have different capture area layouts.
+    permissible_values:
+      V1:
+      V2:
+      V3:
+      V4:

--- a/modules/Other/Administrative.yaml
+++ b/modules/Other/Administrative.yaml
@@ -1,0 +1,15 @@
+enums:
+  ProgressReportNumberEnum:
+    description: Milestone the data is associated with; used for NTAP, GFF, and NFRI funded projects.
+    permissible_values:
+      '1':
+      '2':
+      '3':
+      '4':
+      '5':
+      '6':
+      '7':
+      '8':
+      '9':
+      '10':
+      Not Applicable:

--- a/modules/Other/Epidemiology.yaml
+++ b/modules/Other/Epidemiology.yaml
@@ -1,0 +1,8 @@
+enums:
+  EpidemiologyMetricEnum:
+    description: Common metrics used in epidemiology studies.
+    permissible_values:
+      Standardized Incidence Ratio:
+      Incidence Rate:
+      Mortality Rate:
+      Standardized Mortality Ratio:

--- a/modules/Other/Software.yaml
+++ b/modules/Other/Software.yaml
@@ -1,0 +1,13 @@
+enums:
+  ProgrammingLanguageEnum:
+    description: A computer programming language.
+    permissible_values:
+      Python:
+      R:
+      MATLAB:
+      Java:
+      C:
+      C++:
+      C#:
+      Javascript:
+      bash:

--- a/modules/props.yaml
+++ b/modules/props.yaml
@@ -140,14 +140,17 @@ slots:
     required: false
   averageBaseQuality:
     description: Average base quality collected from samtools
+    range: float
     title: Average Base Quality
     required: false
   averageInsertSize:
     description: Average insert size as reported by samtools
+    range: float
     title: Average Insert Size
     required: false
   averageReadLength:
     description: Average read length collected from samtools
+    range: float
     title: Average Read Length
     required: false
   batchID:
@@ -185,15 +188,7 @@ slots:
     description: 'One of the either four or two active regions where tissue can be placed on a Visium slide. Each area is intended to contain only one tissue sample.  Slide areas are named consecutively from top to bottom:  A1, B1, C1, D1 for Visium slides with 6.5 mm Capture Area and A, B for CytAssist slides with 11 mm Capture Area.  Both CytAssist slides with 6.5 mm Capture Area and Gateway Slides contain only two slide areas, A1 and D1.
 
       '
-    enum_range:
-    - A
-    - B
-    - C
-    - D
-    - A1
-    - B1
-    - C1
-    - D1
+    range: CaptureAreaEnum
     title: Capture Area
     required: false
   cellID:
@@ -245,6 +240,7 @@ slots:
     title: Comments
   compoundDose:
     description: A dose quantity for the treatment compound. To be used with compoundDoseUnit.
+    range: float
     title: Compound Dose
     required: false
   compoundDoseUnit:
@@ -267,6 +263,7 @@ slots:
     required: false
   concentrationNaCl:
     description: Numeric value for NaCl concentration
+    range: float
     title: Concentration Na Cl
     required: false
   concentrationNaClUnit:
@@ -341,10 +338,7 @@ slots:
     required: false
   dataCollectionMode:
     description: Mode of data collection in tandem MS assays. Either DDA (data-dependent acquisition) or DIA (data-independent) acquisition.
-    enum_range:
-    - DDA
-    - DIA
-    - Other
+    range: DataCollectionModeEnum
     title: Data Collection Mode
     required: true
   dataFileHandleId:
@@ -453,11 +447,7 @@ slots:
     required: false
   epidemiologyMetric:
     description: Common metrics used in epidemiology studies.
-    enum_range:
-    - Standardized Incidence Ratio
-    - Incidence Rate
-    - Mortality Rate
-    - Standardized Mortality Ratio
+    range: EpidemiologyMetricEnum
     title: Epidemiology Metric
     required: true
   etag:
@@ -616,11 +606,7 @@ slots:
     required: false
   immersion:
     description: Immersion medium
-    enum_range:
-    - air
-    - oil
-    - water
-    - other
+    range: ImmersionEnum
     title: Immersion
     required: false
   individualID:
@@ -662,6 +648,7 @@ slots:
     required: false
   isFilteredReads:
     description: Whether the reads in the processed result has been filtered by adding a 'PASS' filter or other filters as determined by the data generator
+    range: BooleanEnum
     title: Is Filtered Reads
     required: false
   isMultiIndividual:
@@ -846,6 +833,7 @@ slots:
     required: false
   meanCoverage:
     description: Mean coverage for whole genome sequencing, or mean target coverage for whole exome and targeted sequencing, collected from Picard Tools
+    range: float
     title: Mean Coverage
     required: false
   meningioma:
@@ -1005,19 +993,7 @@ slots:
     required: false
   peakCallingAlgorithm:
     description: A list of commonly used peak-calling algorithms for ChIP-Seq data analysis.
-    enum_range:
-    - MACS2
-    - SICER
-    - HOMER
-    - Genrich
-    - PeakRanger
-    - SEACR
-    - GEM
-    - MUSIC
-    - BroadPeak
-    - SWEMBL
-    - FSeq
-    - ZINBA
+    range: PeakCallingAlgorithmEnum
     title: Peak Calling Algorithm
     required: false
   peripheralNeuropathy:
@@ -1066,32 +1042,12 @@ slots:
     required: false
   programmingLanguage:
     description: A computer programming language
-    enum_range:
-    - Python
-    - R
-    - MATLAB
-    - Java
-    - C
-    - C++
-    - C#
-    - Javascript
-    - bash
+    range: ProgrammingLanguageEnum
     title: Programming Language
     required: false
   progressReportNumber:
     description: 'Indicates milestone the  data is associated with. Currently only required for projects funded by NTAP, GFF, and NFRI. For GFF studies, this is the ‘progress report’ timeline. Example: if submitting data for the 6-month milestone report for NTAP, progressReportNumber=1.  Also if submitting data associated with first milestone, progressReportNumber =1'
-    enum_range:
-    - '1'
-    - '2'
-    - '3'
-    - '4'
-    - '5'
-    - '6'
-    - '7'
-    - '8'
-    - '9'
-    - '10'
-    - Not Applicable
+    range: ProgressReportNumberEnum
     title: Progress Report Number
     required: false
   proportionCoverage10x:
@@ -1186,6 +1142,7 @@ slots:
     required: false
   readsDuplicatedPercent:
     description: Percent of duplicated reads collected from samtools
+    range: float
     title: Reads Duplicated Percent
     required: false
   readsMappedPercent:
@@ -1195,12 +1152,7 @@ slots:
     required: false
   recordingSource:
     description: Source of electrophysiology recording.
-    enum_range:
-    - electrode
-    - tetrode
-    - shank
-    - Utah array
-    - other electrode array
+    range: RecordingSourceEnum
     title: Recording Source
     required: false
   referenceSequence:
@@ -1295,11 +1247,7 @@ slots:
     required: false
   slideVersion:
     description: Version of imaging slide used. Slide version is critical for the analysis of the sequencing data as different slides have different capture area layouts.
-    enum_range:
-    - V1
-    - V2
-    - V3
-    - V4
+    range: SlideVersionEnum
     title: Slide Version
     required: false
   sourceName:
@@ -1416,6 +1364,7 @@ slots:
     required: false
   targetDepth:
     description: The targeted read depth prior to sequencing.
+    range: integer
     title: Target Depth
     required: false
   timepointUnit:

--- a/tests/data/ChIPSeqTemplate/invalid_peakcalling_unlisted.json
+++ b/tests/data/ChIPSeqTemplate/invalid_peakcalling_unlisted.json
@@ -1,0 +1,5 @@
+{
+  "fileFormat": "bed",
+  "resourceType": "metadata",
+  "peakCallingAlgorithm": "NotARealPeakCaller"
+}

--- a/tests/data/ChIPSeqTemplate/invalid_peakcalling_unlisted.json
+++ b/tests/data/ChIPSeqTemplate/invalid_peakcalling_unlisted.json
@@ -1,5 +1,17 @@
 {
-  "fileFormat": "bed",
-  "resourceType": "metadata",
-  "peakCallingAlgorithm": "NotARealPeakCaller"
+  "assay": "ChIP-seq",
+  "dataSubtype": "processed",
+  "dataType": "chromatin activity",
+  "diagnosis": "Neurofibromatosis type 1",
+  "fileFormat": "bed narrowPeak",
+  "individualID": ["NF-003"],
+  "libraryPreparationMethod": "KAPA HyperPrep Kit PCR-free",
+  "libraryStrand": "Unstranded",
+  "peakCallingAlgorithm": "NotARealPeakCaller",
+  "platform": "Illumina NovaSeq 6000",
+  "resourceType": "experimentalData",
+  "species": "Homo sapiens",
+  "specimenID": "NF-003-T1",
+  "specimenPreparationMethod": "Flash frozen",
+  "tumorType": "Plexiform Neurofibroma"
 }

--- a/tests/data/ChIPSeqTemplate/valid_peakcalling_macs2.json
+++ b/tests/data/ChIPSeqTemplate/valid_peakcalling_macs2.json
@@ -1,0 +1,5 @@
+{
+  "fileFormat": "bed",
+  "resourceType": "metadata",
+  "peakCallingAlgorithm": "MACS2"
+}

--- a/tests/data/ChIPSeqTemplate/valid_peakcalling_macs2.json
+++ b/tests/data/ChIPSeqTemplate/valid_peakcalling_macs2.json
@@ -1,5 +1,17 @@
 {
-  "fileFormat": "bed",
-  "resourceType": "metadata",
-  "peakCallingAlgorithm": "MACS2"
+  "assay": "ChIP-seq",
+  "dataSubtype": "processed",
+  "dataType": "chromatin activity",
+  "diagnosis": "Neurofibromatosis type 1",
+  "fileFormat": "bed narrowPeak",
+  "individualID": ["NF-003"],
+  "libraryPreparationMethod": "KAPA HyperPrep Kit PCR-free",
+  "libraryStrand": "Unstranded",
+  "peakCallingAlgorithm": "MACS2",
+  "platform": "Illumina NovaSeq 6000",
+  "resourceType": "experimentalData",
+  "species": "Homo sapiens",
+  "specimenID": "NF-003-T1",
+  "specimenPreparationMethod": "Flash frozen",
+  "tumorType": "Plexiform Neurofibroma"
 }

--- a/tests/test_registry_slot_types.yaml
+++ b/tests/test_registry_slot_types.yaml
@@ -1,0 +1,20 @@
+# Slot range typing (issue #930): verify that slots which previously fell back
+# to the default `string` range now enforce their assigned type.
+#
+# peakCallingAlgorithm migrated from a stripped inline `enum_range` to the named
+# PeakCallingAlgorithmEnum, so the generated schema now enforces the controlled
+# vocabulary instead of accepting any string.
+#
+# resourceType is "metadata" (not "experimentalData") so the #825 relaxed
+# requirements do not apply and these cases isolate the peakCallingAlgorithm slot.
+
+schema: ChIPSeqTemplate
+instances:
+  - file: data/ChIPSeqTemplate/valid_peakcalling_macs2.json
+    description: peakCallingAlgorithm set to an allowed vocabulary value (MACS2)
+    expected: valid
+
+  - file: data/ChIPSeqTemplate/invalid_peakcalling_unlisted.json
+    description: peakCallingAlgorithm set to a value outside the PeakCallingAlgorithmEnum vocabulary
+    expected: invalid
+    reason: peakCallingAlgorithm "NotARealPeakCaller" is not a permissible PeakCallingAlgorithmEnum value

--- a/tests/test_registry_slot_types.yaml
+++ b/tests/test_registry_slot_types.yaml
@@ -5,8 +5,9 @@
 # PeakCallingAlgorithmEnum, so the generated schema now enforces the controlled
 # vocabulary instead of accepting any string.
 #
-# resourceType is "metadata" (not "experimentalData") so the #825 relaxed
-# requirements do not apply and these cases isolate the peakCallingAlgorithm slot.
+# Both instances are complete, realistic ChIP-seq peak-call records that satisfy
+# every ChIPSeqTemplate required slot. They differ only in peakCallingAlgorithm,
+# so the invalid case fails on that slot alone and not on missing requirements.
 
 schema: ChIPSeqTemplate
 instances:


### PR DESCRIPTION
Addresses #930 (Phase 1). Many top-level slots have no explicit `range` and fall back to `default_range: string`, losing JSON-Schema typing and validation. This is a deliberately **conservative, low-risk first pass**; the remaining slots are handled in follow-ups (see Deferred).

## Changes

### Recover 9 controlled vocabularies as named enums
These slots documented an inline `enum_range`, but the build **silently strips `enum_range`** (`Makefile`: `yq 'del(.. | select(has("enum_range")).enum_range)'`), so today they emit plain `string` with no enforcement. Promoted to named enums using the **identical values** (no change to accepted values):

`captureArea`, `dataCollectionMode`, `epidemiologyMetric`, `immersion`, `peakCallingAlgorithm`, `programmingLanguage`, `progressReportNumber`, `recordingSource`, `slideVersion`

New enums: 6 assay/experiment ones in `modules/Assay/Parameter.yaml`; `ProgrammingLanguageEnum`, `EpidemiologyMetricEnum`, `ProgressReportNumberEnum` in new small topical files under `modules/Other/`.

### Type numeric metric slots
`float`: `averageBaseQuality`, `averageInsertSize`, `averageReadLength`, `compoundDose`, `concentrationNaCl`, `meanCoverage`, `readsDuplicatedPercent`
`integer`: `targetDepth`
(mirrors already-typed siblings like `readDepth`, `readsMappedPercent`.)

### Type a boolean flag
`isFilteredReads` → `BooleanEnum` (repo house convention models booleans as a Yes/No enum, not native `boolean`).

### Tests
Added `tests/test_registry_slot_types.yaml` + fixtures validating `peakCallingAlgorithm` enum enforcement on `ChIPSeqTemplate` (valid `MACS2` / invalid unlisted value), following the existing `xfail`-strict registry-test pattern.

## Deferred to follow-up PRs (intentionally not here)
- Value-reconciliation enums: `materialType` (vs `Material`), `transplantationRecipientSpecies` (common→scientific names vs `SpeciesEnum`)
- `cytassistSample` (True/False → Yes/No migration), `reporterSubstance` (no vocabulary yet)
- URI typing (`uriorcurie` — no precedent in the model today), Synapse platform-managed system fields (intentionally `string`), dates, and a gene-symbol enum
- A pre-release backward-compatibility audit of existing Synapse annotations before tightening types

## Notes
- Verified locally: merged model builds and every new `range:` resolves (no dangling references); enums/types materialize correctly; no existing `tests/data/**` fixture uses any changed slot (no regression).
- Generated artifacts (`registered-json-schemas/`, `dist/`) are intentionally **not** committed, per repo convention — CI rebuilds and Synapse-validates them, and the `peakCallingAlgorithm` test validates against the CI-regenerated schema.