### PR TITLE
Add hosting, repository, externalUrl slots to Dataset schema

### DIFF
--- a/modules/DCC/Portal.yaml
+++ b/modules/DCC/Portal.yaml
@@ -131,6 +131,22 @@ enums:
       NIH-NCI:
       NTAP:
       Other:
+  HostingEnum:
+    description: Where a dataset's files physically live and whether they are downloadable through Synapse. This is distinct from access type (permission). Blank/absent is semantically "synapse".
+    permissible_values:
+      synapse:
+        description: Files are in Synapse/Sage-managed storage (S3/GCP). Standard download. The default.
+      external-cloud:
+        description: Files are in a third-party (non-Sage) cloud bucket; downloadable like Synapse files, but the bucket owner could remove them.
+      external-download:
+        description: Files are in an external repository (e.g. GEO, ENA, figshare, Zenodo) and directly downloadable through Synapse clients, but served externally (may be slow or go dead).
+      external-access:
+        description: Data is NOT downloadable through Synapse (e.g. dbGaP, EGA, LONI); access requires an external process. The card links out instead of downloading.
+      mixed:
+        description: Files span more than one location; some download through Synapse, some are hosted/controlled externally.
+      unavailable:
+        description: Indexed for discovery, but not downloadable through Synapse and with no external location to link to (distinct from external-access).
+    title: Hosting
   License:
     description: License attached to the data. If indicates UNKNOWN or RESTRICTED-USE, data may not be used without further contact for terms.
     notes:

--- a/modules/Template/PortalDataset.yaml
+++ b/modules/Template/PortalDataset.yaml
@@ -116,11 +116,26 @@ classes:
         range: string
         required: false
         title: External Repository URI
+      externalUrl:
+        description: "URL the dataset card links users to for external-access datasets
+          (a repository landing page, record, or DOI). Display/link target only; optional
+          for other hosting types."
+        range: string
+        required: false
+        title: External URL
       funder:
         multivalued: true
         range: FundingAgencyEnum
         required: true
         title: Funder
+      hosting:
+        description: Where the dataset's files physically live and whether they are
+          downloadable through Synapse. Drives the data portal card's download/access
+          action. Distinct from accessType (which is about permission). Blank/absent
+          is semantically "synapse".
+        range: HostingEnum
+        required: false
+        title: Hosting
       includedInDataCatalog:
         description: Link(s) to known data catalog(s) the dataset is included in.
         range: DataCatalogEnum
@@ -166,6 +181,14 @@ classes:
         - range: CellBasedAssayEnum
         - range: DrugScreenAssayEnum
         title: Measurement Technique
+      repository:
+        description: Human-readable name of the external repository shown in the data
+          portal card label/tooltip (e.g. "GEO", "ENA", "figshare", "Zenodo", "dbGaP",
+          "EGA", "LONI"). Display label only; does not change behavior. Relevant for
+          external-download, external-access, and mixed hosting.
+        range: string
+        required: false
+        title: Repository
       series:
         description: Datasets may belong to a curated series. Should be assigned by
           staff only; omit property if not applicable/unknown.


### PR DESCRIPTION
## Summary

Adds three optional slots to the `PortalDataset` schema to drive a hosting-aware download/access button on the NF data portal dataset cards. The portal already reads all three columns; a blank/unknown `hosting` falls back to `synapse` (a normal Download button), so this rolls out safely and incrementally.

- **`hosting`** — controlled enum (new `HostingEnum`) with six kebab-case values:
  - `synapse` — Synapse/Sage-managed storage; standard download (the default).
  - `external-cloud` — third-party cloud bucket; downloadable like Synapse files, but owner could remove them.
  - `external-download` — external repo (GEO, ENA, figshare, Zenodo); directly downloadable through Synapse clients but served externally.
  - `external-access` — NOT downloadable through Synapse (dbGaP, EGA, LONI); card links out.
  - `mixed` — files span more than one location.
  - `unavailable` — indexed for discovery, nothing to download or link to.
  - Blank/absent is semantically `synapse`. This axis is **distinct from `accessType`** (permission vs. where files live).
- **`repository`** — free text; human-readable external repository name for the card label/tooltip (e.g. GEO, Zenodo, dbGaP).
- **`externalUrl`** — free text (URL); link target for `external-access` cards.

All three are `required: false`.

## Files
- `modules/DCC/Portal.yaml` — new `HostingEnum`.
- `modules/Template/PortalDataset.yaml` — `hosting`, `repository`, `externalUrl` attributes.

## Validation
- `make -B` + `gen-json-schema-class.py --class PortalDataset` + `make Superdataset` build cleanly; `hosting` compiles to the six-value enum, all three optional and absent from `required`.
- `pytest` (schema instances + template datatypes + model-system sync): 29 passed, 22 xfailed.
- `check_schema_limits.py --strict`: passed.

Build artifacts (`dist/`, `registered-json-schemas/`) are intentionally not committed here; CI rebuilds and commits them to `main` after merge, and the live JSON schema is registered on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)