### PR TITLE
Bump js-yaml to 4.3.1 to fix CVE-2026-59869 (SEC-486)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nf-metadata-dictionary-docs",
       "version": "1.0.0",
       "dependencies": {
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.1",
         "n3": "^1.22.3"
       }
     },
@@ -113,9 +113,19 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "build": "node build.mjs"
   },
   "dependencies": {
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.3.1",
     "n3": "^1.22.3"
   }
 }


### PR DESCRIPTION
## Summary
- osv-scanner flagged js-yaml 4.1.1 (HIGH) in `docs/package.json` for CVE-2026-59869 (scan 2026-07-23)
- Bumps `js-yaml` to 4.3.1 in `docs/package.json` and `docs/package-lock.json`, within the fixed range (3.15.0+ or 4.3.0+)

Resolves SEC-486.

## Test plan
- [x] `npm install --package-lock-only` regenerated the lockfile cleanly with 0 vulnerabilities reported
- [ ] CI build of `docs/` site passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)