### PR TITLE
Add Sheba Medical Center to Institution enum

### DIFF
--- a/modules/Other/Organization.yaml
+++ b/modules/Other/Organization.yaml
@@ -339,6 +339,8 @@ enums:
         meaning: ''
       Seattle Children's:
         meaning: ''
+      Sheba Medical Center:
+        source: https://ror.org/020rzx487
       South Dakota State University:
         meaning: ''
       Southern Illinois University, Carbondale:


### PR DESCRIPTION
## Summary

Adds a single new permissible value to the `Institution` enum in `modules/Other/Organization.yaml`:

| Term | Source |
| --- | --- |
| Sheba Medical Center | https://ror.org/020rzx487 |

Sheba Medical Center (Chaim Sheba Medical Center) is a public medical center and research hospital in Ramat Gan, Israel, established 1948.
The `source` field uses its ROR record, matching the convention established for other institutions with ROR IDs (e.g. `Children's of Alabama`, `Lurie Children's Hospital`).

The term is inserted in alphabetical position, between `Seattle Children's` and `South Dakota State University`.

## Notes

- Generated artifacts (`dist/`, `registered-json-schemas/`) are intentionally not included in this PR - CI rebuilds them on `main`.

## Test plan

- [x] `modules/Other/Organization.yaml` parses as valid YAML and contains exactly one `Sheba Medical Center` entry
- [x] Full model merge succeeds (`yq eval-all` over `header.yaml`, `modules/props.yaml`, `modules/**/*.yaml`) and the merged schema resolves `enums.Institution.permissible_values["Sheba Medical Center"]` to `source: https://ror.org/020rzx487`
- [x] ROR ID verified against the ROR v2 API (`Sheba Medical Center`, Israel, status `active`)
- [x] main-ci passes (LinkML build + lint/validate of `dist/NF.yaml`, schema tests)