### PR TITLE
Address enum gap for allowable platforms/fileFormats 

### DIFF
--- a/modules/Template/Data_Imaging.yaml
+++ b/modules/Template/Data_Imaging.yaml
@@ -29,6 +29,7 @@ classes:
         - range: MicroscopyImagingPlatformEnum
         - range: MRIPlatformEnum
         - range: ImagingSystemPlatformEnum
+        - range: OtherPlatformEnum
         required: false
       fileFormat:
         any_of:

--- a/modules/Template/Data_Proteomics.yaml
+++ b/modules/Template/Data_Proteomics.yaml
@@ -21,7 +21,8 @@ classes:
         range: MassSpectrometryPlatformEnum
         required: false
       fileFormat:
-        range: MassSpecFileFormatEnum
+        any_of:
+        - range: MassSpecFileFormatEnum
 
       specimenID:
         required: false
@@ -73,7 +74,9 @@ classes:
       platform:
         range: MassSpectrometryPlatformEnum
       fileFormat:
-        range: MassSpecFileFormatEnum
+        any_of:
+        - range: MassSpecFileFormatEnum
+        - range: TabularFileFormatEnum
 
       dataCollectionMode:
         required: false
@@ -107,7 +110,9 @@ classes:
       platform:
         range: MassSpectrometryPlatformEnum
       fileFormat:
-        range: MassSpecFileFormatEnum
+        any_of:
+        - range: MassSpecFileFormatEnum
+        - range: TabularFileFormatEnum
 
   KinomicsAssayTemplate:
     annotations:


### PR DESCRIPTION
Closes #950.

- `modules/Template/Data_Imaging.yaml`: Added OtherPlatformEnum back to ImagingAssayTemplate.platform's any_of, restoring the "Other Platform" option (matching what MicroscopyAssayTemplate already does).
- `modules/Template/Data_Proteomics.yaml`: Changed fileFormat on MassSpecAssayTemplate and ProteomicsAssayTemplate to any_of: [MassSpecFileFormatEnum, TabularFileFormatEnum], enabling tabular auxiliary report formats (csv, excel, tsv, txt, parquet, RCC).