### PR TITLE
Update curation task utils, building on new synapseclient support

### DIFF
--- a/.github/workflows/create-curation-task.yml
+++ b/.github/workflows/create-curation-task.yml
@@ -128,8 +128,7 @@ jobs:
 
       - name: Install Synapse Python client
         run: |
-          # Install from develop branch which has curation task support
-          pip install git+https://github.com/Sage-Bionetworks/synapsePythonClient.git@develop
+          pip install 'synapseclient>=4.12.0'
 
       - name: Create curation task and bind schema
         id: create_task

--- a/.github/workflows/create-curation-task.yml
+++ b/.github/workflows/create-curation-task.yml
@@ -96,7 +96,7 @@ on:
         type: boolean
         default: false
       assignee:
-        description: 'Username, email, team name, or numeric principal ID to assign the task to (optional). Existing folder permissions are checked, not granted.'
+        description: 'Username, team name, or numeric principal ID to assign the task to (optional; email lookup is not supported by Synapse). Existing folder permissions are checked, not granted.'
         required: false
         type: string
         default: ''

--- a/.github/workflows/create-curation-task.yml
+++ b/.github/workflows/create-curation-task.yml
@@ -95,6 +95,11 @@ on:
         required: false
         type: boolean
         default: false
+      assignee:
+        description: 'Username, email, team name, or numeric principal ID to assign the task to (optional). Existing folder permissions are checked, not granted.'
+        required: false
+        type: string
+        default: ''
       create_issue:
         description: 'Create mirror GitHub issue with task info'
         required: false
@@ -141,6 +146,7 @@ jobs:
             --instructions "${{ inputs.instructions }}" \
             --bind-schema \
             ${{ inputs.replace && '--replace' || '' }} \
+            ${{ inputs.assignee != '' && format('--assignee "{0}"', inputs.assignee) || '' }} \
             --output-format github
 
       - name: Display task summary
@@ -153,6 +159,7 @@ jobs:
           echo "- **Data Type:** ${{ steps.create_task.outputs.data_type }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Template:** ${{ inputs.template }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Schema URI:** ${{ steps.create_task.outputs.schema_uri }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Assignee (Synapse principal ID):** ${{ steps.create_task.outputs.assignee_principal_id != '' && steps.create_task.outputs.assignee_principal_id || 'Not assigned' }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Resources Created" >> $GITHUB_STEP_SUMMARY
           echo "- **Project:** [${{ steps.create_task.outputs.project_id }}](https://www.synapse.org/#!Synapse:${{ steps.create_task.outputs.project_id }})" >> $GITHUB_STEP_SUMMARY
@@ -178,6 +185,7 @@ jobs:
           - **Data Type:** ${{ steps.create_task.outputs.data_type }}
           - **Template:** ${{ inputs.template }}
           - **Schema URI:** ${{ steps.create_task.outputs.schema_uri }}
+          - **Assignee (Synapse principal ID):** ${{ steps.create_task.outputs.assignee_principal_id != '' && steps.create_task.outputs.assignee_principal_id || 'Not assigned' }}
 
           ### Resources Created
           - **Project:** [${{ steps.create_task.outputs.project_id }}](https://www.synapse.org/#!Synapse:${{ steps.create_task.outputs.project_id }})

--- a/dev/DEVELOPMENT.md
+++ b/dev/DEVELOPMENT.md
@@ -252,9 +252,16 @@ It checks:
 Synapse curation tasks support structured metadata collection with registered JSON schemas. Two task types are supported.
 
 > [!IMPORTANT]
-> Requires `synapseclient>=4.12.0` (both scripts rely on `synapseclient.extensions.curator`):
+> Requires `synapseclient>=4.12.0` (both scripts rely on `synapseclient.extensions.curator`).
+> `create_recordset_task.py` additionally requires `pandas`, which `synapseclient` does not
+> pull in: `create_record_based_metadata_task()` imports it, so a bare `synapseclient` install
+> fails with `ModuleNotFoundError: No module named 'pandas'`.
 > ```bash
+> # file-based tasks (create_curation_task.py)
 > pip install 'synapseclient>=4.12.0'
+>
+> # record-based tasks (create_recordset_task.py)
+> pip install 'synapseclient>=4.12.0' pandas
 > ```
 
 #### Wrapper vs. synapseclient
@@ -316,7 +323,7 @@ SYNAPSE_AUTH_TOKEN="$TOKEN" python utils/create_curation_task.py \
 | `--instructions` | Instructions for contributors | "Please add metadata for your files" |
 | `--bind-schema` / `--no-bind-schema` | Bind schema to folder | True |
 | `--replace` | Delete any existing curation task for this folder and rebind the schema before creating a new one; use when switching templates | False |
-| `--assignee` | Username, email, team name, or numeric principal ID to assign the task to; existing folder permissions are checked (not granted) | None |
+| `--assignee` | Username, team name, or numeric principal ID to assign the task to; existing folder permissions are checked (not granted). Email addresses are *not* supported — Synapse does not allow principal lookup by email | None |
 | `--output-format` | `json` or `github` | `json` |
 
 **Output:** `task_id`, `fileview_id`, `data_type`, `schema_uri`, `project_id`, `assignee_principal_id`

--- a/dev/DEVELOPMENT.md
+++ b/dev/DEVELOPMENT.md
@@ -266,10 +266,10 @@ lost if these scripts were ever replaced by direct client calls.
 | What our wrapper adds | Why synapseclient doesn't cover it |
 |---|---|
 | Local, short template name → `schema_uri` resolution (reads `registered-json-schemas/{template}.json`) | The client takes a `schema_uri` only; wrapper allows convenient short-name reference by taking advantage of registered-json-schemas folder  |
-| Enforces our team's task naming convention — `dataType` is auto-generated as `{folder_name} ({folder_id})`, not left to the caller | The client's `curation_task_name` is used verbatim as `data_type`; it has no naming convention of its own, let alone ours |
+| Enforces our team's task naming convention — `dataType` is auto-generated as `{folder_name} ({folder_id})` | The client's `curation_task_name` is used verbatim as `data_type`; it has no naming convention of its own, let alone ours |
 | Pre-flight check for files that already have annotations matching the new template's fields | No equivalent — the client has no awareness of annotation state before task creation |
-| `--replace` (delete the stale task and rebind the schema when switching templates on an already-configured folder) | No equivalent, and it wouldn't know this repo's one-task-per-folder convention even if it existed |
-| `--assignee` + a permission check (warns if the assignee lacks `READ`/`CREATE`/`UPDATE` on the folder; never grants access) | The client accepts `assignee_principal_id` as task metadata but does nothing about folder ACLs — it has no notion that a curation task implies future writes by the assignee |
+| `--replace` (delete the stale task and rebind the schema when switching templates on an already-configured folder) | No equivalent, this convenience was added in #875 |
+| `--assignee` + a permission check (warns if the assignee lacks `READ`/`CREATE`/`UPDATE` on the folder; never grants access) | `assignee_principal_id` implies future writes by the assignee so permissions should be checked, and client doesn't do this |
 | Sized `STRING`/list columns (max 80 chars / 20 items) instead of unbounded `MEDIUMTEXT` | The client's own column builder doesn't account for Synapse's 64KB file-view row limit; using it as-is would reintroduce a real production incident (PR #843, `ScRNASeqTemplate` row-size breach) |
 
 What we *do* delegate to the client (as of `synapseclient>=4.12.0`):
@@ -291,10 +291,7 @@ We deliberately do **not** call `synapseclient.extensions.curator.create_file_ba
 **What it creates:**
 - EntityView (file view) with schema-derived columns
 - CurationTask bound to the folder
-- `dataType` (the task's display name in Synapse), enforced as `{folder_name} ({folder_id})` —
-  this is our team's required naming convention, not a suggestion: it lets curators identify a
-  task by the folder it curates rather than by an internal template/schema name, and the caller
-  cannot override it
+- `dataType` (the task's display name in Synapse), enforced as `{folder_name} ({folder_id})`
 
 **Usage:**
 ```bash

--- a/dev/DEVELOPMENT.md
+++ b/dev/DEVELOPMENT.md
@@ -252,9 +252,9 @@ It checks:
 Synapse curation tasks support structured metadata collection with registered JSON schemas. Two task types are supported.
 
 > [!IMPORTANT]
-> Currently, this functionality requires synapsePythonClient develop branch:
+> Requires `synapseclient>=4.12.0` (both scripts rely on `synapseclient.extensions.curator`):
 > ```bash
-> pip install git+https://github.com/Sage-Bionetworks/synapsePythonClient.git@develop
+> pip install 'synapseclient>=4.12.0'
 > ```
 
 #### File-Based Curation Tasks

--- a/dev/DEVELOPMENT.md
+++ b/dev/DEVELOPMENT.md
@@ -257,6 +257,31 @@ Synapse curation tasks support structured metadata collection with registered JS
 > pip install 'synapseclient>=4.12.0'
 > ```
 
+#### Wrapper vs. synapseclient
+
+Both scripts build on top of `synapseclient`'s curation task support, but they are not
+thin passthroughs to it. The table below is the actual diff, so it's clear what would be
+lost if these scripts were ever replaced by direct client calls.
+
+| What our wrapper adds | Why synapseclient doesn't cover it |
+|---|---|
+| Local, short template name → `schema_uri` resolution (reads `registered-json-schemas/{template}.json`) | The client takes a `schema_uri` only; wrapper allows convenient short-name reference by taking advantage of registered-json-schemas folder  |
+| Enforces our team's task naming convention — `dataType` is auto-generated as `{folder_name} ({folder_id})`, not left to the caller | The client's `curation_task_name` is used verbatim as `data_type`; it has no naming convention of its own, let alone ours |
+| Pre-flight check for files that already have annotations matching the new template's fields | No equivalent — the client has no awareness of annotation state before task creation |
+| `--replace` (delete the stale task and rebind the schema when switching templates on an already-configured folder) | No equivalent, and it wouldn't know this repo's one-task-per-folder convention even if it existed |
+| `--assignee` + a permission check (warns if the assignee lacks `READ`/`CREATE`/`UPDATE` on the folder; never grants access) | The client accepts `assignee_principal_id` as task metadata but does nothing about folder ACLs — it has no notion that a curation task implies future writes by the assignee |
+| Sized `STRING`/list columns (max 80 chars / 20 items) instead of unbounded `MEDIUMTEXT` | The client's own column builder doesn't account for Synapse's 64KB file-view row limit; using it as-is would reintroduce a real production incident (PR #843, `ScRNASeqTemplate` row-size breach) |
+
+What we *do* delegate to the client (as of `synapseclient>=4.12.0`):
+- `project_id_from_entity_id()` for folder→project traversal (replaced a hand-rolled loop)
+- `Folder.bind_schema()` for schema binding — it's a PUT, so rebinding just overwrites; no manual unbind step needed
+- `EntityView`'s own default columns (`include_default_columns=True`) + `reorder_column()`, instead of manually constructing `id`/`name` columns (which collided with the defaults and risked corrupting `id`'s special meaning)
+- `CurationTask.store()`'s built-in non-destructive upsert (merges by `project_id` + `data_type` automatically)
+- `assignee_principal_id` on `CurationTask`, passed straight through
+
+We deliberately do **not** call `synapseclient.extensions.curator.create_file_based_metadata_task()` /
+`create_json_schema_entity_view()` wholesale — see the column-sizing row above.
+
 #### File-Based Curation Tasks
 
 **Use case:** Associate metadata with uploaded files in a folder (e.g., sequencing data, images).
@@ -266,7 +291,10 @@ Synapse curation tasks support structured metadata collection with registered JS
 **What it creates:**
 - EntityView (file view) with schema-derived columns
 - CurationTask bound to the folder
-- Auto-generated dataType: `{template_base}-{folder_id}`
+- `dataType` (the task's display name in Synapse), enforced as `{folder_name} ({folder_id})` —
+  this is our team's required naming convention, not a suggestion: it lets curators identify a
+  task by the folder it curates rather than by an internal template/schema name, and the caller
+  cannot override it
 
 **Usage:**
 ```bash
@@ -287,12 +315,14 @@ SYNAPSE_AUTH_TOKEN="$TOKEN" python utils/create_curation_task.py \
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--folder-id` | Upload folder Synapse ID (required) | - |
-| `--template` | Template name or schema URI (required) | - |
+| `--template` | Template name *or* schema URI (required) | - |
 | `--instructions` | Instructions for contributors | "Please add metadata for your files" |
 | `--bind-schema` / `--no-bind-schema` | Bind schema to folder | True |
+| `--replace` | Delete any existing curation task for this folder and rebind the schema before creating a new one; use when switching templates | False |
+| `--assignee` | Username, email, team name, or numeric principal ID to assign the task to; existing folder permissions are checked (not granted) | None |
 | `--output-format` | `json` or `github` | `json` |
 
-**Output:** `task_id`, `fileview_id`, `data_type`, `schema_uri`, `project_id`
+**Output:** `task_id`, `fileview_id`, `data_type`, `schema_uri`, `project_id`, `assignee_principal_id`
 
 #### Record-Based Curation Tasks
 

--- a/utils/create_curation_task.py
+++ b/utils/create_curation_task.py
@@ -140,12 +140,15 @@ def check_existing_annotations(folder_id: str, schema_fields: set, syn) -> bool:
 
 def resolve_principal_id(identifier: str, syn) -> str:
     """
-    Resolve a username, email, team name, or numeric ID to a Synapse principal ID.
+    Resolve a username, team name, or numeric ID to a Synapse principal ID.
+
+    Synapse does not support looking up principals by email address, so emails
+    are not accepted.
 
     Tries a user profile lookup first, then falls back to a team lookup.
 
     Args:
-        identifier: Username, email, team name, or numeric user/team ID
+        identifier: Username, team name, or numeric user/team ID
         syn: Authenticated Synapse client
 
     Returns:
@@ -168,7 +171,8 @@ def resolve_principal_id(identifier: str, syn) -> str:
 
     raise ValueError(
         f"Could not resolve '{identifier}' to a Synapse user or team. "
-        "Provide a username, email, team name, or numeric principal ID."
+        "Provide a username, team name, or numeric principal ID "
+        "(Synapse does not support lookup by email address)."
     )
 
 
@@ -293,7 +297,7 @@ def create_curation_task(
         bind_schema: Whether to bind JSON schema to folder (default: True)
         replace: If True, delete any existing curation task for this folder and
                  rebind the schema before creating a new task (default: False)
-        assignee: Username, email, team name, or numeric principal ID to assign the
+        assignee: Username, team name, or numeric principal ID to assign the
                   task to (optional). If provided, the assignee's existing permissions
                   on the upload folder are checked and a warning is printed if they're
                   insufficient — this script never modifies folder sharing settings.
@@ -534,7 +538,8 @@ Notes:
         '--assignee',
         default=None,
         help=(
-            'Username, email, team name, or numeric principal ID to assign the task to. '
+            'Username, team name, or numeric principal ID to assign the task to '
+            '(email addresses are not supported by Synapse). '
             'Existing folder permissions for the assignee are checked and a warning is '
             'printed if insufficient; this script never modifies folder sharing settings.'
         )

--- a/utils/create_curation_task.py
+++ b/utils/create_curation_task.py
@@ -11,7 +11,8 @@ The dataType is auto-generated from the template name and folder ID.
 The project ID is derived from the folder.
 
 Requirements:
-  pip install git+https://github.com/Sage-Bionetworks/synapsePythonClient.git@develop
+  synapseclient>=4.12.0 (needs synapseclient.extensions.curator.utils.project_id_from_entity_id,
+  not available in earlier releases)
 """
 
 import argparse
@@ -25,12 +26,17 @@ def load_schema_uri(template_name_or_uri: str, schema_dir: str = "registered-jso
     """
     Load the schema URI and schema content from a registered JSON schema file or external URI.
 
+    The returned schema_uri is always normalized to the short form (e.g.
+    'org.synapse.nf-imagingassaytemplate'), matching what synapseclient's own
+    bind_schema()/create_file_based_metadata_task() examples use, even though
+    registered schema files' $id (and externally-provided URIs) are full URLs.
+
     Args:
         template_name_or_uri: Template name (e.g., 'ImagingAssayTemplate') or full schema URI
         schema_dir: Directory containing schema files (only used for local templates)
 
     Returns:
-        Tuple of (schema_uri, schema_dict)
+        Tuple of (schema_uri, schema_dict), schema_uri normalized to short form
 
     Raises:
         FileNotFoundError: If schema file doesn't exist
@@ -38,8 +44,9 @@ def load_schema_uri(template_name_or_uri: str, schema_dir: str = "registered-jso
     """
     # Check if it's a full URI
     if template_name_or_uri.startswith('http://') or template_name_or_uri.startswith('https://'):
-        # External URI provided - use it directly and fetch schema if needed
-        return template_name_or_uri, None  # Schema content not available for external URIs
+        # External URI provided - normalize to short form; schema content is fetched
+        # separately by the caller using the original full URI
+        return template_name_or_uri.split('/')[-1], None
 
     # Local template name - load from file
     repo_root = Path(__file__).parent.parent
@@ -58,7 +65,11 @@ def load_schema_uri(template_name_or_uri: str, schema_dir: str = "registered-jso
     if "$id" not in schema:
         raise KeyError(f"Schema file {schema_file} is missing required '$id' field")
 
-    return schema["$id"], schema
+    schema_id = schema["$id"]
+    if schema_id.startswith('http://') or schema_id.startswith('https://'):
+        schema_id = schema_id.split('/')[-1]
+
+    return schema_id, schema
 
 
 def generate_datatype(template_name: str, folder_id: str) -> str:
@@ -75,33 +86,6 @@ def generate_datatype(template_name: str, folder_id: str) -> str:
     # Remove "Template" suffix if present
     base_name = template_name.removesuffix("Template")
     return f"{base_name}-{folder_id}"
-
-
-def unbind_schema_from_folder(folder_id: str, syn) -> bool:
-    """
-    Unbind any existing JSON schema from a Synapse folder.
-
-    Args:
-        folder_id: Synapse folder ID
-        syn: Authenticated Synapse client
-
-    Returns:
-        True if a schema was removed, False if none was bound
-    """
-    from synapseclient.services.json_schema import JsonSchemaService
-
-    json_schema_service = JsonSchemaService(syn)
-    try:
-        json_schema_service.delete_json_schema_from_entity(synapse_id=folder_id)
-        print("✓ Existing schema unbound from folder")
-        return True
-    except Exception as e:
-        if "not found" in str(e).lower() or "no schema" in str(e).lower() or "404" in str(e):
-            print("  No existing schema binding found (skipping unbind)")
-            return False
-        else:
-            print(f"⚠ Warning: Could not unbind schema: {e}")
-            return False
 
 
 def check_existing_annotations(folder_id: str, schema_fields: set, syn) -> bool:
@@ -149,6 +133,82 @@ def check_existing_annotations(folder_id: str, schema_fields: set, syn) -> bool:
     return False
 
 
+def resolve_principal_id(identifier: str, syn) -> str:
+    """
+    Resolve a username, email, team name, or numeric ID to a Synapse principal ID.
+
+    Tries a user profile lookup first, then falls back to a team lookup.
+
+    Args:
+        identifier: Username, email, team name, or numeric user/team ID
+        syn: Authenticated Synapse client
+
+    Returns:
+        The resolved principal ID as a string
+
+    Raises:
+        ValueError: If identifier does not resolve to a user or team
+    """
+    try:
+        profile = syn.getUserProfile(identifier)
+        return str(profile.ownerId)
+    except Exception:
+        pass
+
+    try:
+        team = syn.getTeam(identifier)
+        return str(team.id)
+    except Exception:
+        pass
+
+    raise ValueError(
+        f"Could not resolve '{identifier}' to a Synapse user or team. "
+        "Provide a username, email, team name, or numeric principal ID."
+    )
+
+
+# Access types a data contributor needs on the upload folder to actually complete
+# the task: READ/CREATE to add new files, UPDATE to edit annotations on them.
+REQUIRED_ASSIGNEE_ACCESS = {"READ", "CREATE", "UPDATE"}
+
+
+def check_assignee_permissions(folder_id: str, principal_id: str, syn) -> bool:
+    """
+    Check (without modifying) whether an assignee has sufficient permissions on the
+    upload folder to complete a curation task. Checks the folder's benefactor, so
+    permissions inherited from the parent project/folder are taken into account.
+
+    Args:
+        folder_id: Synapse folder ID the task uploads to
+        principal_id: Principal ID (user or team) to check
+        syn: Authenticated Synapse client
+
+    Returns:
+        True if the assignee has all of READ, CREATE, and UPDATE access; False otherwise
+    """
+    from synapseclient.models import Folder
+
+    print(f"\nChecking permissions for principal {principal_id} on folder {folder_id}...")
+    access_types = set(
+        Folder(id=folder_id).get_acl(principal_id=int(principal_id), synapse_client=syn)
+    )
+    missing = REQUIRED_ASSIGNEE_ACCESS - access_types
+
+    if missing:
+        print(
+            f"⚠ Warning: assignee {principal_id} is missing permissions on {folder_id}: "
+            f"{sorted(missing)} (has: {sorted(access_types) or 'none'})"
+        )
+        print(
+            "  This script does not grant permissions — the assignee may not be able to "
+            "upload files or annotate them until folder sharing settings are updated."
+        )
+        return False
+
+    print(f"  ✓ Assignee has required permissions: {sorted(access_types)}")
+    return True
+
+
 def delete_existing_curation_task(folder_id: str, project_id: str, syn) -> bool:
     """
     Find and delete any existing curation task whose upload folder matches folder_id.
@@ -177,46 +237,32 @@ def delete_existing_curation_task(folder_id: str, project_id: str, syn) -> bool:
     return deleted
 
 
-def bind_schema_to_folder(
-    folder_id: str,
-    schema_uri: str,
-    syn,
-    replace: bool = False
-) -> bool:
+def bind_schema_to_folder(folder_id: str, schema_uri: str, syn) -> bool:
     """
     Bind a JSON schema to a Synapse folder.
+
+    Binding is a PUT (replace) on the Synapse side, so rebinding a folder that
+    already has a schema simply overwrites the existing binding — no unbind step
+    is needed first, even when switching to a different template.
 
     Args:
         folder_id: Synapse folder ID
         schema_uri: JSON schema URI
         syn: Authenticated Synapse client
-        replace: If True, unbind any existing schema before binding
 
     Returns:
-        True if binding succeeded, False if already bound and replace=False
+        True if binding succeeded, False otherwise
     """
-    from synapseclient.services.json_schema import JsonSchemaService
+    from synapseclient.models import Folder
 
     print(f"\nBinding schema to folder {folder_id}...")
-    json_schema_service = JsonSchemaService(syn)
-
-    if replace:
-        unbind_schema_from_folder(folder_id, syn)
-
     try:
-        json_schema_service.bind_json_schema_to_entity(
-            synapse_id=folder_id,
-            json_schema_uri=schema_uri
-        )
+        Folder(id=folder_id).bind_schema(json_schema_uri=schema_uri, synapse_client=syn)
         print("✓ Schema bound successfully")
         return True
     except Exception as e:
-        if "already" in str(e).lower() or "bound" in str(e).lower():
-            print(f"⚠ Schema already bound to folder (skipping)")
-            return False
-        else:
-            print(f"⚠ Warning: Could not bind schema: {e}")
-            return False
+        print(f"⚠ Warning: Could not bind schema: {e}")
+        return False
 
 
 def create_curation_task(
@@ -225,6 +271,7 @@ def create_curation_task(
     instructions: str = "Please add metadata for your files",
     bind_schema: bool = True,
     replace: bool = False,
+    assignee: str = None,
     auth_token: str = None
 ) -> dict:
     """
@@ -241,12 +288,17 @@ def create_curation_task(
         bind_schema: Whether to bind JSON schema to folder (default: True)
         replace: If True, delete any existing curation task for this folder and
                  rebind the schema before creating a new task (default: False)
+        assignee: Username, email, team name, or numeric principal ID to assign the
+                  task to (optional). If provided, the assignee's existing permissions
+                  on the upload folder are checked and a warning is printed if they're
+                  insufficient — this script never modifies folder sharing settings.
         auth_token: Synapse authentication token (if None, reads from env)
 
     Returns:
         Dictionary with task_id, fileview_id, data_type, schema_uri, and project_id
     """
     from synapseclient import Synapse
+    from synapseclient.extensions.curator.utils import project_id_from_entity_id
     from synapseclient.models.curation import (
         CurationTask,
         FileBasedMetadataTaskProperties
@@ -265,27 +317,18 @@ def create_curation_task(
     syn = Synapse()
     syn.login(authToken=auth_token)
 
-    # Get folder to derive project ID
     print(f"Getting folder information: {upload_folder_id}")
-    folder = syn.get(upload_folder_id, downloadFile=False)
-
-    # Try to get project ID - may need to traverse hierarchy
-    project_id = None
-    if hasattr(folder, 'properties') and folder.properties:
-        project_id = folder.properties.get('projectId')
-
-    # If not in properties, traverse parent hierarchy to find project
-    if not project_id:
-        print("  Project ID not in folder properties, traversing hierarchy...")
-        current = folder
-        while current.get('concreteType') != 'org.sagebionetworks.repo.model.Project':
-            parent_id = current.get('parentId')
-            if not parent_id:
-                raise ValueError(f"Could not find project for folder {upload_folder_id}")
-            current = syn.get(parent_id, downloadFile=False)
-        project_id = current.id
+    project_id = project_id_from_entity_id(upload_folder_id, synapse_client=syn)
 
     print(f"  Project: {project_id}")
+
+    # Resolve assignee and check (but do not modify) their folder permissions
+    assignee_principal_id = None
+    if assignee:
+        print(f"\nResolving assignee: {assignee}")
+        assignee_principal_id = resolve_principal_id(assignee, syn)
+        print(f"  Principal ID: {assignee_principal_id}")
+        check_assignee_permissions(upload_folder_id, assignee_principal_id, syn)
 
     # Load schema URI and content
     print(f"\nLoading schema: {template}")
@@ -294,10 +337,11 @@ def create_curation_task(
 
     # Fetch schema content now if not already loaded (external URI case),
     # so schema fields are available for the annotation check below.
+    # Uses the original full URI (`template`), since schema_uri is now the short form.
     if json_schema is None:
         print("  Fetching schema from URI...")
         import requests
-        response = requests.get(schema_uri)
+        response = requests.get(template)
         if response.status_code == 200:
             json_schema = response.json()
         else:
@@ -307,9 +351,9 @@ def create_curation_task(
     # Determine template name for dataType generation
     # If full URI provided, extract template name or use a default
     if template.startswith('http://') or template.startswith('https://'):
-        # Extract template name from URI if possible
+        # Extract template name from the (already short-form) schema_uri if possible
         # e.g., sage.schemas.v2571-nf.ChIPSeqTemplate.schema-9.14.0 -> ChIPSeqTemplate
-        uri_parts = schema_uri.split('/')[-1].split('.')
+        uri_parts = schema_uri.split('.')
         template_name = next((part for part in uri_parts if 'Template' in part), template.replace('https://', '').replace('http://', '').split('/')[0])
     else:
         template_name = template
@@ -319,7 +363,7 @@ def create_curation_task(
     print(f"  Generated dataType: {data_type}")
 
     # Warn early if files already have annotations matching the template fields,
-    # before any destructive action (schema unbind / task delete).
+    # before any destructive action (task delete / schema rebind).
     schema_fields = set(json_schema.get("properties", {}).keys())
     if schema_fields:
         check_existing_annotations(upload_folder_id, schema_fields, syn)
@@ -330,13 +374,14 @@ def create_curation_task(
 
     # Optionally bind schema to folder
     if bind_schema:
-        bind_schema_to_folder(upload_folder_id, schema_uri, syn, replace=replace)
+        bind_schema_to_folder(upload_folder_id, schema_uri, syn)
 
-    # Create EntityView (file view) using the better implementation from json_schema_entity_view
+    # Create EntityView (file view) using the better implementation from json_schema_entity_view.
+    # Columns are deliberately sized (STRING max 80 chars, lists capped at 20 items) to stay
+    # within Synapse's 64KB file view row limit -- see utils/check_schema_limits.py.
     print(f"\nCreating file view for folder...")
-    from synapseclient.models import Column, ColumnType, ViewTypeMask, EntityView
+    from synapseclient.models import ViewTypeMask, EntityView
 
-    # Create columns from schema using the helper function
     import sys
     sys.path.insert(0, str(Path(__file__).parent))
     from json_schema_entity_view import _create_columns_from_json_schema
@@ -348,23 +393,18 @@ def create_curation_task(
         print(f"  ⚠ Schema has no properties: {e}")
         columns = []
 
-    # Add essential columns first: id and name only
-    essential_columns = [
-        Column(name="id", column_type=ColumnType.ENTITYID),
-        Column(name="name", column_type=ColumnType.STRING, maximum_size=256),
-    ]
-
-    # Combine essential columns with schema columns
-    all_columns = essential_columns + columns
-
-    # Create the entity view using the new models API
+    # Default columns (id, name, etc.) are added automatically; create with just the
+    # schema-derived columns, then move id/name to the front for readability.
     file_view = EntityView(
         name=f"{data_type}_FileView",
         parent_id=project_id,
         scope_ids=[upload_folder_id],
         view_type_mask=ViewTypeMask.FILE,
-        columns=all_columns,
+        columns=columns,
     ).store(synapse_client=syn)
+    file_view.reorder_column(name="name", index=0)
+    file_view.reorder_column(name="id", index=0)
+    file_view = file_view.store(synapse_client=syn)
 
     print(f"  File View ID: {file_view.id}")
 
@@ -372,11 +412,14 @@ def create_curation_task(
     print(f"\nCreating file-based metadata task...")
     print(f"  Folder: {upload_folder_id}")
     print(f"  Data type: {data_type}")
+    if assignee_principal_id:
+        print(f"  Assignee: {assignee_principal_id}")
 
     task = CurationTask(
         project_id=project_id,
         data_type=data_type,
         instructions=instructions,
+        assignee_principal_id=assignee_principal_id,
         task_properties=FileBasedMetadataTaskProperties(
             upload_folder_id=upload_folder_id,
             file_view_id=file_view.id
@@ -394,7 +437,8 @@ def create_curation_task(
         "fileview_id": file_view.id,
         "data_type": data_type,
         "schema_uri": schema_uri,
-        "project_id": project_id
+        "project_id": project_id,
+        "assignee_principal_id": assignee_principal_id
     }
 
 
@@ -426,6 +470,12 @@ Examples:
     --folder-id syn12345678 \\
     --template https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.schemas.v2571-nf.ChIPSeqTemplate.schema-9.14.0
 
+  # Assign the task to a user or team
+  python create_curation_task.py \\
+    --folder-id syn12345678 \\
+    --template ImagingAssayTemplate \\
+    --assignee jsmith
+
 Environment Variables:
   SYNAPSE_AUTH_TOKEN    Synapse authentication token (required)
 
@@ -434,6 +484,8 @@ Notes:
   - DataType is auto-generated as: {template_base}-{folder_id}
   - Schema binding is enabled by default (use --no-bind-schema to skip)
   - Schema URI is loaded from registered-json-schemas/ directory
+  - --assignee only checks the assignee's existing folder permissions and warns
+    if insufficient; it never changes folder sharing settings
         """
     )
 
@@ -481,6 +533,16 @@ Notes:
     )
 
     parser.add_argument(
+        '--assignee',
+        default=None,
+        help=(
+            'Username, email, team name, or numeric principal ID to assign the task to. '
+            'Existing folder permissions for the assignee are checked and a warning is '
+            'printed if insufficient; this script never modifies folder sharing settings.'
+        )
+    )
+
+    parser.add_argument(
         '--output-format',
         choices=['json', 'github'],
         default='json',
@@ -495,7 +557,8 @@ Notes:
             template=args.template,
             instructions=args.instructions,
             bind_schema=args.bind_schema,
-            replace=args.replace
+            replace=args.replace,
+            assignee=args.assignee
         )
 
         if args.output_format == 'github':

--- a/utils/create_curation_task.py
+++ b/utils/create_curation_task.py
@@ -7,7 +7,8 @@ This script automatically:
 - Creates EntityView (file view) for the upload folder
 - Creates CurationTask with specified datatype and instructions
 
-The dataType is auto-generated from the template name and folder ID.
+The task display name is enforced as "{folder name} ({folder ID})" per our
+team's task naming convention.
 The project ID is derived from the folder.
 
 Requirements:
@@ -25,12 +26,7 @@ from pathlib import Path
 def load_schema_uri(template_name_or_uri: str, schema_dir: str = "registered-json-schemas") -> tuple[str, dict]:
     """
     Load the schema URI and schema content from a registered JSON schema file or external URI.
-
-    The returned schema_uri is always normalized to the short form (e.g.
-    'org.synapse.nf-imagingassaytemplate'), matching what synapseclient's own
-    bind_schema()/create_file_based_metadata_task() examples use, even though
-    registered schema files' $id (and externally-provided URIs) are full URLs.
-
+    
     Args:
         template_name_or_uri: Template name (e.g., 'ImagingAssayTemplate') or full schema URI
         schema_dir: Directory containing schema files (only used for local templates)
@@ -48,16 +44,24 @@ def load_schema_uri(template_name_or_uri: str, schema_dir: str = "registered-jso
         # separately by the caller using the original full URI
         return template_name_or_uri.split('/')[-1], None
 
-    # Local template name - load from file
+    # Local template name - load from file (case-insensitive: 'microscopyassaytemplate'
+    # matches 'MicroscopyAssayTemplate.json' just like the properly-cased name would)
     repo_root = Path(__file__).parent.parent
     schema_file = repo_root / schema_dir / f"{template_name_or_uri}.json"
 
     if not schema_file.exists():
-        raise FileNotFoundError(
-            f"Schema file not found: {schema_file}\n"
-            f"Available templates in {schema_dir}/:\n" +
-            "\n".join(f"  - {f.stem}" for f in sorted((repo_root / schema_dir).glob("*.json")))
+        match = next(
+            (f for f in (repo_root / schema_dir).glob("*.json")
+             if f.stem.lower() == template_name_or_uri.lower()),
+            None
         )
+        if match is None:
+            raise FileNotFoundError(
+                f"Schema file not found: {schema_file}\n"
+                f"Available templates in {schema_dir}/:\n" +
+                "\n".join(f"  - {f.stem}" for f in sorted((repo_root / schema_dir).glob("*.json")))
+            )
+        schema_file = match
 
     with open(schema_file, 'r') as f:
         schema = json.load(f)
@@ -72,20 +76,21 @@ def load_schema_uri(template_name_or_uri: str, schema_dir: str = "registered-jso
     return schema_id, schema
 
 
-def generate_datatype(template_name: str, folder_id: str) -> str:
+def generate_task_name(folder_name: str, folder_id: str) -> str:
     """
-    Generate a unique dataType identifier.
+    Synapse raw API uses param `dataType` for setting task display name, which is rather confusing.
+    This generates the CurationTask's `dataType`, enforcing our current task naming convention 
+    that simply uses the dataset folder name - ultimately we should use whatever format is most understandable to folks. 
+    It is easiest to identify tasks by the folder they're curating.
 
     Args:
-        template_name: Name of the template (e.g., 'ImagingAssayTemplate')
+        folder_name: Name of the upload folder (e.g., 'RNA-seq for Cohort 1')
         folder_id: Synapse folder ID (e.g., 'syn12345678')
 
     Returns:
-        Generated dataType string (e.g., 'ImagingAssay-syn12345678')
+        Generated dataType string (e.g., 'RNA-seq for Cohort 1 (syn12345678)')
     """
-    # Remove "Template" suffix if present
-    base_name = template_name.removesuffix("Template")
-    return f"{base_name}-{folder_id}"
+    return f"{folder_name} ({folder_id})"
 
 
 def check_existing_annotations(folder_id: str, schema_fields: set, syn) -> bool:
@@ -299,6 +304,7 @@ def create_curation_task(
     """
     from synapseclient import Synapse
     from synapseclient.extensions.curator.utils import project_id_from_entity_id
+    from synapseclient.models import Folder
     from synapseclient.models.curation import (
         CurationTask,
         FileBasedMetadataTaskProperties
@@ -318,8 +324,10 @@ def create_curation_task(
     syn.login(authToken=auth_token)
 
     print(f"Getting folder information: {upload_folder_id}")
+    folder_name = Folder(id=upload_folder_id).get(synapse_client=syn).name
     project_id = project_id_from_entity_id(upload_folder_id, synapse_client=syn)
 
+    print(f"  Folder: {folder_name}")
     print(f"  Project: {project_id}")
 
     # Resolve assignee and check (but do not modify) their folder permissions
@@ -348,18 +356,8 @@ def create_curation_task(
             print(f"  ⚠ Could not fetch schema from URI (status {response.status_code})")
             json_schema = {}
 
-    # Determine template name for dataType generation
-    # If full URI provided, extract template name or use a default
-    if template.startswith('http://') or template.startswith('https://'):
-        # Extract template name from the (already short-form) schema_uri if possible
-        # e.g., sage.schemas.v2571-nf.ChIPSeqTemplate.schema-9.14.0 -> ChIPSeqTemplate
-        uri_parts = schema_uri.split('.')
-        template_name = next((part for part in uri_parts if 'Template' in part), template.replace('https://', '').replace('http://', '').split('/')[0])
-    else:
-        template_name = template
-
     # Generate dataType
-    data_type = generate_datatype(template_name, upload_folder_id)
+    data_type = generate_task_name(folder_name, upload_folder_id)
     print(f"  Generated dataType: {data_type}")
 
     # Warn early if files already have annotations matching the template fields,
@@ -481,7 +479,7 @@ Environment Variables:
 
 Notes:
   - Project ID is automatically derived from the folder
-  - DataType is auto-generated as: {template_base}-{folder_id}
+  - DataType (task name) is enforced as "{folder_name} ({folder_id})" per team convention, not configurable
   - Schema binding is enabled by default (use --no-bind-schema to skip)
   - Schema URI is loaded from registered-json-schemas/ directory
   - --assignee only checks the assignee's existing folder permissions and warns
@@ -498,7 +496,7 @@ Notes:
     parser.add_argument(
         '--template',
         required=True,
-        help='Template name (e.g., ImagingAssayTemplate) or full schema URI (e.g., https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.schemas.v2571-nf.ChIPSeqTemplate.schema-9.14.0)'
+        help='Template name, case-insensitive (e.g., ImagingAssayTemplate or imagingassaytemplate) or full schema URI (e.g., https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/sage.schemas.v2571-nf.ChIPSeqTemplate.schema-9.14.0)'
     )
 
     parser.add_argument(
@@ -570,12 +568,14 @@ Notes:
                     f.write(f"fileview_id={result['fileview_id']}\n")
                     f.write(f"data_type={result['data_type']}\n")
                     f.write(f"schema_uri={result['schema_uri']}\n")
+                    f.write(f"assignee_principal_id={result['assignee_principal_id'] or ''}\n")
             else:
                 print("\nGitHub Actions outputs:")
                 print(f"task_id={result['task_id']}")
                 print(f"fileview_id={result['fileview_id']}")
                 print(f"data_type={result['data_type']}")
                 print(f"schema_uri={result['schema_uri']}")
+                print(f"assignee_principal_id={result['assignee_principal_id'] or ''}")
         else:
             # JSON output for testing
             print("\nResult:")

--- a/utils/create_recordset_task.py
+++ b/utils/create_recordset_task.py
@@ -8,7 +8,8 @@ This script automatically:
 - Creates a DataGrid interface for the RecordSet
 
 Requirements:
-  pip install git+https://github.com/Sage-Bionetworks/synapsePythonClient.git@develop
+  synapseclient>=4.12.0 (the synapseclient.extensions.curator module is not available
+  in earlier releases)
 """
 
 import argparse
@@ -159,8 +160,8 @@ def create_recordset_task(
     except ImportError:
         raise ImportError(
             "The create_record_based_metadata_task function is not available. "
-            "Please ensure you have the latest develop branch of synapsePythonClient:\n"
-            "  pip install git+https://github.com/Sage-Bionetworks/synapsePythonClient.git@develop"
+            "Please upgrade synapseclient to 4.12.0 or later:\n"
+            "  pip install 'synapseclient>=4.12.0'"
         )
 
     # Create the record-based metadata task

--- a/utils/create_recordset_task.py
+++ b/utils/create_recordset_task.py
@@ -10,6 +10,8 @@ This script automatically:
 Requirements:
   synapseclient>=4.12.0 (the synapseclient.extensions.curator module is not available
   in earlier releases)
+  pandas (required by synapseclient's create_record_based_metadata_task, but not
+  installed as a synapseclient dependency)
 """
 
 import argparse
@@ -165,12 +167,19 @@ def create_recordset_task(
     # Import the helper function from synapseclient
     try:
         from synapseclient.extensions.curator import create_record_based_metadata_task
-    except ImportError:
+    except ImportError as e:
+        # create_record_based_metadata_task imports pandas, which synapseclient does not
+        # install itself, so a missing pandas looks identical to a stale synapseclient here.
+        if getattr(e, "name", None) == "pandas":
+            raise ImportError(
+                "Record-based tasks require pandas, which synapseclient does not install:\n"
+                "  pip install pandas"
+            ) from e
         raise ImportError(
             "The create_record_based_metadata_task function is not available. "
             "Please upgrade synapseclient to 4.12.0 or later:\n"
             "  pip install 'synapseclient>=4.12.0'"
-        )
+        ) from e
 
     # Create the record-based metadata task
     # Build kwargs to conditionally include upsert_keys

--- a/utils/create_recordset_task.py
+++ b/utils/create_recordset_task.py
@@ -41,16 +41,24 @@ def load_schema_uri(template_name_or_uri: str, schema_dir: str = "registered-jso
         # -> org.synapse.nf-datalandscape-0.2.0
         return template_name_or_uri.split('/')[-1]
 
-    # Local template name - load from file
+    # Local template name - load from file (case-insensitive: 'datalandscape'
+    # matches 'DataLandscape.json' just like the properly-cased name would)
     repo_root = Path(__file__).parent.parent
     schema_file = repo_root / schema_dir / f"{template_name_or_uri}.json"
 
     if not schema_file.exists():
-        raise FileNotFoundError(
-            f"Schema file not found: {schema_file}\n"
-            f"Available templates in {schema_dir}/:\n" +
-            "\n".join(f"  - {f.stem}" for f in sorted((repo_root / schema_dir).glob("*.json")))
+        match = next(
+            (f for f in (repo_root / schema_dir).glob("*.json")
+             if f.stem.lower() == template_name_or_uri.lower()),
+            None
         )
+        if match is None:
+            raise FileNotFoundError(
+                f"Schema file not found: {schema_file}\n"
+                f"Available templates in {schema_dir}/:\n" +
+                "\n".join(f"  - {f.stem}" for f in sorted((repo_root / schema_dir).glob("*.json")))
+            )
+        schema_file = match
 
     with open(schema_file, 'r') as f:
         schema = json.load(f)
@@ -262,7 +270,7 @@ Notes:
     parser.add_argument(
         '--template',
         required=True,
-        help='Template name (e.g., ImagingAssayTemplate) or full schema URI'
+        help='Template name, case-insensitive (e.g., ImagingAssayTemplate or imagingassaytemplate) or full schema URI'
     )
 
     parser.add_argument(


### PR DESCRIPTION
Closes #952. This is an overall improvement building on top of recently released client features; the scripts still include guards/niceties you don't get otherwise. Suggesting @aditya-nath-sage be primary reviewer for this one since relevant to a recent CTF project question, but additional eyes/awareness always welcome. 

#### Changes
- Remove stale `@develop references`. Both `create_curation_task.py` and `create_recordset_task.py` predated synapseclient's released curation-task support and pointed at `pip install git+...@develop`. Replaced with accurate version floors (synapseclient>=4.12.0) in all relevant locations.
- Rebuild `create_curation_task.py` on top of newer client utilities, dropping ~90 lines of now-redundant original code:
  - `synapseclient.extensions.curator.utils.project_id_from_entity_id()` replaces a manual folder→project hierarchy walk.
  - `Folder.bind_schema()` replaces the old JsonSchemaService bind/unbind pair — binding is a PUT, so rebinding a folder with a different schema just overwrites; the manual unbind-before-rebind step was unnecessary and is removed.
  - Manually-constructed id/name Columns (which collided with EntityView's own `include_default_columns` defaults and risked corrupting id's special meaning) are gone in favor of `reorder_column()`.
  - Deliberately _did not_ delegate column creation to the client's own builder — it uses unbounded `MEDIUMTEXT`, while ours caps `STRING` at 80 chars / lists at 20 items to stay under Synapse's 64KB file-view row limit. Using the client's builder as-is would have reintroduced that regression. Note: We need a more optimized version bc our templates have a large number of columns.
- Add new `--assignee` support. Resolves a username/email/team name/numeric ID to a Synapse principal ID and sets it on the CurationTask. Adds a permission-check-only step that warns if the assignee lacks READ/CREATE/UPDATE on the upload folder, which means they wouldn't actually be able to curate the files... (the client does not do this check). Expose `--assignee` end-to-end so you can also assign when using Github Actions UI.
- Enforce the latest contributor-friendly task naming convention.
- Case-insensitive `--template` matching for local templates in both scripts.
- Docs: added a "Wrapper vs. synapseclient" comparison table to `dev/DEVELOPMENT.md` spelling out what this wrapper adds beyond the client and why, and what it now delegates to the client.

#### Test plan
- [ ] Create a curation task via CLI with `create_curation_task.py`
- [ ] Create a curation task using GH Actions UI
- [ ] Create a recordset task via CLI with `create_recordset_task.py` (UI not offered for this one)