### PR TITLE
Add .arf file format (hearing test / ABR data)

### DIFF
--- a/modules/Data/FileFormat.yaml
+++ b/modules/Data/FileFormat.yaml
@@ -247,6 +247,12 @@ enums:
       abf:
         description: The Axon Binary File format (ABF) was created for the storage of binary experimental data.
         source: https://mdc.custhelp.com/euf/assets/content/ABFHelp.pdf
+      arf:
+        aliases:
+        - BioSigRZ record file
+        - Averaged Response File
+        description: BioSigRZ record file format from Tucker-Davis Technologies. Stores averaged evoked-response records, such as auditory brainstem response (ABR) and distortion product otoacoustic emission (DPOAE) waveforms, which are appended to the file during acquisition for later retrieval and analysis.
+        source: https://www.tdt.com/docs/biosigrz/data-acquisition/
       dna:
         description: Propietary SnapGene file format.
         source: https://www.snapgene.com/guides/convert-genbank-files

--- a/modules/Data/FileFormat.yaml
+++ b/modules/Data/FileFormat.yaml
@@ -252,6 +252,10 @@ enums:
         - BioSigRZ record file
         - Averaged Response File
         description: BioSigRZ record file format from Tucker-Davis Technologies. Stores averaged evoked-response records, such as auditory brainstem response (ABR) and distortion product otoacoustic emission (DPOAE) waveforms, which are appended to the file during acquisition for later retrieval and analysis.
+        notes:
+        - Not in EDAM as of August 2026; EDAM has no evoked-response or electrophysiology
+          format terms at all. Do not map to EDAM:format_3581 (arff), which is the
+          unrelated Weka Attribute-Relation File Format.
         source: https://www.tdt.com/docs/biosigrz/data-acquisition/
       dna:
         description: Propietary SnapGene file format.

--- a/modules/Template/Data_Clinical.yaml
+++ b/modules/Template/Data_Clinical.yaml
@@ -40,6 +40,7 @@ classes:
         any_of:
         - range: TabularFileFormatEnum
         - range: DocumentFileFormatEnum
+        - range: OtherFileFormatEnum
       dataType:
         ifabsent: string(clinical)
     rules:
@@ -92,7 +93,9 @@ classes:
       assay:
         range: ClinicalBehavioralAssayEnum
       fileFormat:
-        range: TabularFileFormatEnum
+        any_of:
+        - range: TabularFileFormatEnum
+        - range: OtherFileFormatEnum
     rules:
     - description: If experimentalTimepoint is provided, timepointUnit must be provided
       preconditions:


### PR DESCRIPTION
Fixes #954 (NFOSI-2059).

## What `.arf` is

`.arf` is the **BioSigRZ record file** format from Tucker-Davis Technologies. Averaged evoked-response records are appended to the file during acquisition for later retrieval and analysis — in practice, the **auditory brainstem response (ABR)** and **distortion product otoacoustic emission (DPOAE)** waveforms from the hearing tests in the ticket.

Source: [TDT BioSigRZ manual — Data Acquisition](https://www.tdt.com/docs/biosigrz/data-acquisition/)

> Note on the ultrasound hypothesis: I checked, and I found no evidence that `.arf` is an ultrasound imaging format. The Vevo micro-ultrasound platforms in our `Platform` module export `.raw`/`.xml`, not `.arf`. The other common meanings of the extension (WebEx recordings, Abuse Reporting Format) are unrelated. So this PR treats it as the hearing/evoked-response format only. Happy to revisit if the lab confirms otherwise.

## Changes

**`modules/Data/FileFormat.yaml`** — new `arf` value in `OtherFileFormatEnum`, which is where the other instrument/electrophysiology binary formats live (`abf`, `spk`, `fcs`).

**`modules/Template/Data_Clinical.yaml`** — `ClinicalAssayTemplate` and `BehavioralAssayTemplate` are the only two templates whose `assay` range is `ClinicalBehavioralAssayEnum`, i.e. the only ones that accept `auditory brainstem response` / `distortion product otoacoustic emissions`. Neither allowed `OtherFileFormatEnum`, so the new term would not have been selectable for the submitter. Widened both:

| Template | `fileFormat` before | after |
|---|---|---|
| `ClinicalAssayTemplate` | Tabular + Document | Tabular + Document + **Other** |
| `BehavioralAssayTemplate` | Tabular | Tabular + **Other** |

This also incidentally fixes an existing gap: `psydat` (PsychoPy), `edat3` (E-Prime), and `sav` (SPSS) live in `OtherFileFormatEnum` and were unreachable from `BehavioralAssayTemplate` despite being behavioral-data formats.

## Verification

- `make all` succeeds; `arf` appears in `dist/NF.yaml`. Built artifacts are **not** committed — CI rebuilds them on merge.
- `python utils/check_schema_limits.py` → `ALL CHECKS PASSED`. The 2 string-length warnings are pre-existing (identical with these modules stashed).
- Generated JSON schemas for both changed templates and confirmed `arf` is in the flattened `fileFormat` enum (36 values for `ClinicalAssayTemplate`, 29 for `BehavioralAssayTemplate`).

Suggested version bump: **PATCH** — one new child term plus a range widening; no existing value or requirement changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)